### PR TITLE
Add Donations contract

### DIFF
--- a/.mocharc.json
+++ b/.mocharc.json
@@ -1,4 +1,0 @@
-{
-  "require": "ts-node/register/files",
-  "timeout": 20000
-}

--- a/.mocharc.json
+++ b/.mocharc.json
@@ -1,0 +1,4 @@
+{
+  "require": "ts-node/register/files",
+  "timeout": 20000
+}

--- a/contracts/Donations.sol
+++ b/contracts/Donations.sol
@@ -2,6 +2,7 @@
 pragma solidity =0.8.10;
 
 import {AccessControl} from "@openzeppelin/contracts/access/AccessControl.sol";
+import {IAccessControl} from "@openzeppelin/contracts/access/IAccessControl.sol";
 import {Context} from "@openzeppelin/contracts/utils/Context.sol";
 import {ERC721} from "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
@@ -166,13 +167,16 @@ contract Donations is ERC721, AccessControl {
      */
     function burn(uint256 _id) external {
         bool isOwner = ownerOf(_id) == _msgSender();
-        bool expired = metadata[_id].expiry <= _getBlockTimestamp();
+
+        Metadata storage data = metadata[_id];
+
+        bool expired = data.expiry <= _getBlockTimestamp();
 
         require(isOwner || expired, "Donations: not allowed");
 
-        uint256 destinationId = metadata[_id].destinationId;
-        IERC20 token = metadata[_id].token;
-        uint256 amount = metadata[_id].amount;
+        uint256 destinationId = data.destinationId;
+        IERC20 token = data.token;
+        uint256 amount = data.amount;
 
         transferableAmounts[token][destinationId] += amount;
 

--- a/contracts/Donations.sol
+++ b/contracts/Donations.sol
@@ -70,6 +70,8 @@ contract Donations is ERC721, AccessControl {
      * @param _owner Account that will receive the admin role.
      */
     constructor(address _owner) ERC721("Sandclock Donation", "Donations") {
+        require(_owner != address(0x0), "Vault: owner cannot be 0x0");
+
         _setupRole(DEFAULT_ADMIN_ROLE, _owner);
         _setupRole(WORKER_ROLE, _owner);
     }

--- a/contracts/Donations.sol
+++ b/contracts/Donations.sol
@@ -136,8 +136,9 @@ contract Donations is ERC721, AccessControl {
         uint256 length = _params.length;
 
         for (uint256 i = 0; i < length; i++) {
-            uint256 _metadataId = metadataId.current();
             metadataId.increment();
+
+            uint256 _metadataId = metadataId.current();
 
             metadata[_metadataId] = Metadata({
                 destinationId: _params[i].destinationId,

--- a/contracts/Donations.sol
+++ b/contracts/Donations.sol
@@ -6,7 +6,6 @@ import {Context} from "@openzeppelin/contracts/utils/Context.sol";
 import {ERC721} from "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
-import {Counters} from "@openzeppelin/contracts/utils/Counters.sol";
 
 import "hardhat/console.sol";
 
@@ -15,7 +14,6 @@ import "hardhat/console.sol";
  */
 contract Donations is ERC721, AccessControl {
     using SafeERC20 for IERC20;
-    using Counters for Counters.Counter;
 
     bytes32 public constant WORKER_ROLE = keccak256("WORKER_ROLE");
 
@@ -54,7 +52,7 @@ contract Donations is ERC721, AccessControl {
 
     event TTLUpdated(uint64 ttl);
 
-    Counters.Counter private metadataId;
+    uint256 private metadataId;
     mapping(uint256 => Metadata) public metadata;
 
     /// Duration of the expiration date for new donations.
@@ -136,21 +134,19 @@ contract Donations is ERC721, AccessControl {
         uint256 length = _params.length;
 
         for (uint256 i = 0; i < length; i++) {
-            metadataId.increment();
+            metadataId += 1;
 
-            uint256 _metadataId = metadataId.current();
-
-            metadata[_metadataId] = Metadata({
+            metadata[metadataId] = Metadata({
                 destinationId: _params[i].destinationId,
                 token: _params[i].token,
                 expiry: expiry,
                 amount: _params[i].amount
             });
 
-            _mint(_params[i].owner, _metadataId);
+            _mint(_params[i].owner, metadataId);
 
             emit DonationMinted(
-                _metadataId,
+                metadataId,
                 _params[i].destinationId,
                 groupId,
                 _params[i].token,

--- a/contracts/Donations.sol
+++ b/contracts/Donations.sol
@@ -5,9 +5,11 @@ import {ERC721} from "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 import {Context} from "@openzeppelin/contracts/utils/Context.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {AccessControl} from "@openzeppelin/contracts/access/AccessControl.sol";
+
 import "hardhat/console.sol";
 
-contract Donations is ERC721("Sandclock Donation", "Donations") {
+contract Donations is ERC721, AccessControl {
     using SafeERC20 for IERC20;
 
     struct DonationParams {
@@ -30,23 +32,53 @@ contract Donations is ERC721("Sandclock Donation", "Donations") {
 
     mapping(uint256 => Metadata) public metadata;
 
-    mapping(bytes32 => bool) public processedTx;
+    mapping(bytes32 => bool) public processedDonationsGroups;
 
     mapping(IERC20 => mapping(uint256 => uint256)) public transferableAmounts;
 
+    constructor(address _owner) ERC721("Sandclock Donation", "Donations") {
+        _setupRole(DEFAULT_ADMIN_ROLE, _owner);
+    }
+
+    /**
+     * Transfers the donated funds in the currency @param _token to the charity with the id @param _destinationId.
+     *
+     * @param _destinationId ID of the charity.
+     * @param _token Currency to transfer the funds from.
+     * @param _to Address of the charity.
+     */
     function donate(
         uint256 _destinationId,
         IERC20 _token,
         address _to
-    ) external {
+    ) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        require(
+            transferableAmounts[_token][_destinationId] != 0,
+            "Donations: nothing to donate"
+        );
+
         uint256 amount = transferableAmounts[_token][_destinationId];
         transferableAmounts[_token][_destinationId] = 0;
 
         _token.safeTransfer(_to, amount);
     }
 
-    function mint(bytes32 _txHash, DonationParams[] calldata _params) external {
-        require(processedTx[_txHash] == false, "Donations: already processed");
+    /**
+     * This function mints an NFT for every donation in @param _params.
+     * The @param _donationsId is used to uniquely identify this collection of donations.
+     * Ideally, @param _donationsId is the hash of the transaction where the yield for the donations was claimed to by the treasury.
+     *
+     * @param _donationsId Unique identifier for the group of donations in @param _params.
+     * @param _params Donation params.
+     */
+    function mint(bytes32 _donationsId, DonationParams[] calldata _params)
+        external
+        onlyRole(DEFAULT_ADMIN_ROLE)
+    {
+        require(
+            processedDonationsGroups[_donationsId] == false,
+            "Donations: already processed"
+        );
 
         uint64 expiry = _getBlockTimestamp() + TTL;
         uint256 length = _params.length;
@@ -64,11 +96,20 @@ contract Donations is ERC721("Sandclock Donation", "Donations") {
             _mint(_params[i].owner, _metadataId);
         }
 
-        processedTx[_txHash] = true;
+        processedDonationsGroups[_donationsId] = true;
     }
 
+    /**
+     * Burns the NFT and sets the amount donated to be transferred to the charity.
+     *
+     * @param _id ID of the NFT.
+     */
     function burn(uint256 _id) external {
-        require(ownerOf(_id) == _msgSender());
+        require(
+            ownerOf(_id) == _msgSender() ||
+                hasRole(DEFAULT_ADMIN_ROLE, _msgSender()),
+            "Donations: not allowed"
+        );
 
         uint256 destinationId = metadata[_id].destinationId;
         IERC20 token = metadata[_id].token;
@@ -81,5 +122,15 @@ contract Donations is ERC721("Sandclock Donation", "Donations") {
 
     function _getBlockTimestamp() private view returns (uint64) {
         return uint64(block.timestamp);
+    }
+
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        virtual
+        override(AccessControl, ERC721)
+        returns (bool)
+    {
+        return super.supportsInterface(interfaceId);
     }
 }

--- a/contracts/Donations.sol
+++ b/contracts/Donations.sol
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity =0.8.10;
+
+import {ERC721} from "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+import {Context} from "@openzeppelin/contracts/utils/Context.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "hardhat/console.sol";
+
+contract Donations is ERC721("Sandclock Donation", "Donations") {
+    using SafeERC20 for IERC20;
+
+    struct DonationParams {
+        uint256 destinationId;
+        address owner;
+        IERC20 token;
+        uint256 amount;
+    }
+
+    struct Metadata {
+        uint256 destinationId;
+        IERC20 token;
+        uint256 amount;
+        uint64 expiry;
+    }
+
+    uint256 public metadataId;
+
+    uint64 public constant TTL = 180 days;
+
+    mapping(uint256 => Metadata) public metadata;
+
+    mapping(bytes32 => bool) public processedTx;
+
+    mapping(IERC20 => mapping(uint256 => uint256)) public transferableAmounts;
+
+    function donate(
+        uint256 _destinationId,
+        IERC20 _token,
+        address _to
+    ) external {
+        uint256 amount = transferableAmounts[_token][_destinationId];
+        transferableAmounts[_token][_destinationId] = 0;
+
+        _token.safeTransfer(_to, amount);
+    }
+
+    function mint(bytes32 _txHash, DonationParams[] calldata _params) external {
+        require(processedTx[_txHash] == false, "Donations: already processed");
+
+        uint64 expiry = _getBlockTimestamp() + TTL;
+        uint256 length = _params.length;
+
+        for (uint256 i = 0; i < length; i++) {
+            uint256 _metadataId = ++metadataId;
+
+            metadata[_metadataId] = Metadata({
+                destinationId: _params[i].destinationId,
+                token: _params[i].token,
+                expiry: expiry,
+                amount: _params[i].amount
+            });
+
+            _mint(_params[i].owner, _metadataId);
+        }
+
+        processedTx[_txHash] = true;
+    }
+
+    function burn(uint256 _id) external {
+        require(ownerOf(_id) == _msgSender());
+
+        uint256 destinationId = metadata[_id].destinationId;
+        IERC20 token = metadata[_id].token;
+        uint256 amount = metadata[_id].amount;
+
+        transferableAmounts[token][destinationId] += amount;
+
+        _burn(_id);
+    }
+
+    function _getBlockTimestamp() private view returns (uint64) {
+        return uint64(block.timestamp);
+    }
+}

--- a/contracts/Donations.sol
+++ b/contracts/Donations.sol
@@ -107,9 +107,9 @@ contract Donations is ERC721, AccessControl {
         uint256 amount = transferableAmounts[_token][_destinationId];
         transferableAmounts[_token][_destinationId] = 0;
 
-        _token.safeTransfer(_to, amount);
-
         emit DonationsSent(_destinationId, _token, _to, amount);
+
+        _token.safeTransfer(_to, amount);
     }
 
     /**

--- a/contracts/Donations.sol
+++ b/contracts/Donations.sol
@@ -2,13 +2,10 @@
 pragma solidity =0.8.10;
 
 import {AccessControl} from "@openzeppelin/contracts/access/AccessControl.sol";
-import {IAccessControl} from "@openzeppelin/contracts/access/IAccessControl.sol";
 import {Context} from "@openzeppelin/contracts/utils/Context.sol";
 import {ERC721} from "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
-
-import "hardhat/console.sol";
 
 /**
  * A contract to store donations before they are transferred to the charities.

--- a/contracts/Donations.sol
+++ b/contracts/Donations.sol
@@ -170,10 +170,9 @@ contract Donations is ERC721, AccessControl {
      */
     function burn(uint256 _id) external {
         bool isOwner = ownerOf(_id) == _msgSender();
-        bool isWorker = hasRole(WORKER_ROLE, _msgSender());
         bool expired = metadata[_id].expiry <= _getBlockTimestamp();
 
-        require(isOwner || (isWorker && expired), "Donations: not allowed");
+        require(isOwner || expired, "Donations: not allowed");
 
         uint256 destinationId = metadata[_id].destinationId;
         IERC20 token = metadata[_id].token;

--- a/contracts/Donations.sol
+++ b/contracts/Donations.sol
@@ -161,10 +161,11 @@ contract Donations is ERC721, AccessControl {
      * @param _id ID of the NFT.
      */
     function burn(uint256 _id) external {
-        require(
-            ownerOf(_id) == _msgSender() || hasRole(WORKER_ROLE, _msgSender()),
-            "Donations: not allowed"
-        );
+        bool isOwner = ownerOf(_id) == _msgSender();
+        bool isWorker = hasRole(WORKER_ROLE, _msgSender());
+        bool expired = metadata[_id].expiry <= _getBlockTimestamp();
+
+        require(isOwner || (isWorker && expired), "Donations: not allowed");
 
         uint256 destinationId = metadata[_id].destinationId;
         IERC20 token = metadata[_id].token;

--- a/contracts/Donations.sol
+++ b/contracts/Donations.sol
@@ -121,7 +121,7 @@ contract Donations is ERC721, AccessControl {
         onlyRole(WORKER_ROLE)
     {
         require(
-            processedDonationsGroups[_groupId] == false,
+            !processedDonationsGroups[_groupId],
             "Donations: already processed"
         );
 

--- a/test/Donations.spec.ts
+++ b/test/Donations.spec.ts
@@ -227,7 +227,7 @@ describe("Donations", () => {
       ).to.equal(parseUnits("100"));
     });
 
-    it("works if the caller is the admin and the NFT already expired", async () => {
+    it("works if the NFT is expired", async () => {
       const ttl = BigNumber.from(time.duration.days(14).toNumber());
       await donations.setTTL(ttl);
 
@@ -242,7 +242,7 @@ describe("Donations", () => {
 
       await moveForwardTwoWeeks();
 
-      await donations.connect(owner).burn(1);
+      await donations.connect(bob).burn(1);
 
       expect(
         await donations.transferableAmounts(underlying.address, CHARITY_ID)
@@ -315,7 +315,7 @@ describe("Donations", () => {
       expect(await donations.metadata(4)).to.be.ok;
     });
 
-    it.only("mints the correct NFT", async () => {
+    it("mints the correct NFT", async () => {
       const ttl = BigNumber.from(time.duration.days(180).toNumber());
       await donations.setTTL(ttl);
 

--- a/test/Donations.spec.ts
+++ b/test/Donations.spec.ts
@@ -7,7 +7,11 @@ import { BigNumber, utils } from "ethers";
 import type { Donations } from "../typechain";
 import { MockDAI, MockDAI__factory } from "../typechain";
 import { donationParams } from "./shared/factories";
-import { getLastBlockTimestamp, moveForwardTwoWeeks } from "./shared";
+import {
+  getLastBlockTimestamp,
+  getRoleErrorMsg,
+  moveForwardTwoWeeks,
+} from "./shared";
 
 const { parseUnits } = ethers.utils;
 
@@ -61,7 +65,7 @@ describe("Donations", () => {
       const newTTL = BigNumber.from(time.duration.days(100).toNumber());
 
       await expect(donations.connect(alice).setTTL(newTTL)).to.be.revertedWith(
-        `AccessControl: account ${alice.address.toLocaleLowerCase()} is missing role ${DEFAULT_ADMIN_ROLE}`
+        getRoleErrorMsg(alice, DEFAULT_ADMIN_ROLE)
       );
     });
   });
@@ -161,9 +165,7 @@ describe("Donations", () => {
         donations
           .connect(alice)
           .donate(CHARITY_ID, underlying.address, bob.address)
-      ).to.be.revertedWith(
-        `AccessControl: account ${alice.address.toLocaleLowerCase()} is missing role ${WORKER_ROLE}`
-      );
+      ).to.be.revertedWith(getRoleErrorMsg(alice, WORKER_ROLE));
     });
   });
 
@@ -363,9 +365,7 @@ describe("Donations", () => {
             owner: owner.address,
           }),
         ])
-      ).to.be.revertedWith(
-        `AccessControl: account ${alice.address.toLocaleLowerCase()} is missing role ${WORKER_ROLE}`
-      );
+      ).to.be.revertedWith(getRoleErrorMsg(alice, WORKER_ROLE));
     });
 
     it("fails if the donations group was already processed", async () => {

--- a/test/Donations.spec.ts
+++ b/test/Donations.spec.ts
@@ -4,7 +4,8 @@ import { expect } from "chai";
 import { time } from "@openzeppelin/test-helpers";
 import { BigNumber } from "ethers";
 
-import type { Donations, TestERC20 } from "../typechain";
+import type { Donations } from "../typechain";
+import { MockDAI, MockDAI__factory } from "../typechain";
 import { donationParams } from "./shared/factories";
 import { getLastBlockTimestamp } from "./shared";
 
@@ -21,7 +22,7 @@ describe("Donations", () => {
   let bob: SignerWithAddress;
   let carol: SignerWithAddress;
   let donations: Donations;
-  let underlying: TestERC20;
+  let underlying: MockDAI;
   let WORKER_ROLE: string;
   let DEFAULT_ADMIN_ROLE: string;
 
@@ -29,9 +30,9 @@ describe("Donations", () => {
     [owner, alice, bob, carol] = await ethers.getSigners();
 
     const Donations = await ethers.getContractFactory("Donations");
-    const TestERC20 = await ethers.getContractFactory("TestERC20");
+    const MockDAI = await ethers.getContractFactory("MockDAI");
 
-    underlying = (await TestERC20.deploy(0)) as TestERC20;
+    underlying = (await MockDAI.deploy(0)) as MockDAI;
     donations = (await Donations.deploy(owner.address)) as Donations;
     WORKER_ROLE = await donations.WORKER_ROLE();
     DEFAULT_ADMIN_ROLE = await donations.DEFAULT_ADMIN_ROLE();

--- a/test/Donations.spec.ts
+++ b/test/Donations.spec.ts
@@ -1,0 +1,128 @@
+import type { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import { ethers } from "hardhat";
+import { expect } from "chai";
+
+import type { Donations, TestERC20 } from "../typechain";
+import { donationParams } from "./shared/factories";
+import { constants } from "ethers";
+
+const { parseUnits } = ethers.utils;
+
+const DUMMY_TX =
+  "0x5bdfd14fcc917abc2f02a30721d152a6f147f09e8cbaad4e0d5405d646c5c3e1";
+
+const CHARITY_ID = 1;
+
+describe("Donations", () => {
+  let owner: SignerWithAddress;
+  let alice: SignerWithAddress;
+  let bob: SignerWithAddress;
+  let carol: SignerWithAddress;
+  let donations: Donations;
+  let underlying: TestERC20;
+
+  beforeEach(async () => {
+    [owner, alice, bob, carol] = await ethers.getSigners();
+
+    const Donations = await ethers.getContractFactory("Donations");
+    const TestERC20 = await ethers.getContractFactory("TestERC20");
+
+    underlying = (await TestERC20.deploy(0)) as TestERC20;
+    donations = (await Donations.deploy()) as Donations;
+  });
+
+  describe("donate", () => {
+    it("transfers the amount the charity", async () => {
+      // set donated amount
+      await underlying.mint(donations.address, parseUnits("200"));
+
+      // create donations
+      await donations.mint(DUMMY_TX, [
+        donationParams.build({
+          destinationId: CHARITY_ID,
+          amount: parseUnits("100"),
+          owner: alice.address,
+          token: underlying.address,
+        }),
+        donationParams.build({
+          destinationId: CHARITY_ID,
+          amount: parseUnits("100"),
+          owner: alice.address,
+          token: underlying.address,
+        }),
+      ]);
+
+      // burn donations
+      await donations.connect(alice).burn("1");
+      await donations.connect(alice).burn("2");
+
+      // donate
+      await donations.donate(CHARITY_ID, underlying.address, bob.address);
+
+      expect(await underlying.balanceOf(bob.address)).to.equal(
+        parseUnits("200")
+      );
+    });
+  });
+
+  describe("burn", () => {
+    it("adds the donated amount to the charity", async () => {
+      await donations.mint(DUMMY_TX, [
+        donationParams.build({
+          destinationId: CHARITY_ID,
+          amount: parseUnits("100"),
+          owner: alice.address,
+          token: underlying.address,
+        }),
+      ]);
+
+      expect(
+        await donations.transferableAmounts(underlying.address, CHARITY_ID)
+      ).to.equal(0);
+
+      await donations.connect(alice).burn("1");
+
+      expect(
+        await donations.transferableAmounts(underlying.address, CHARITY_ID)
+      ).to.equal(parseUnits("100"));
+    });
+  });
+
+  describe("mint", () => {
+    it("mints an NFT for every donation", async () => {
+      await donations.mint(DUMMY_TX, [
+        donationParams.build(),
+        donationParams.build(),
+        donationParams.build(),
+        donationParams.build(),
+      ]);
+
+      expect(await donations.metadataId()).to.equal("4");
+    });
+
+    it("mints the correct NFT", async () => {
+      await donations.mint(DUMMY_TX, [
+        donationParams.build({
+          destinationId: CHARITY_ID,
+          amount: parseUnits("1"),
+          token: underlying.address,
+          owner: owner.address,
+        }),
+      ]);
+
+      expect(await donations.ownerOf("1")).to.equal(owner.address);
+
+      const donation = await donations.metadata("1");
+
+      expect(donation.amount).to.equal(parseUnits("1"));
+      expect(donation.destinationId).to.equal(CHARITY_ID);
+      expect(donation.token).to.equal(underlying.address);
+    });
+
+    it("marks the transaction as processed", async () => {
+      await donations.mint(DUMMY_TX, [donationParams.build()]);
+
+      expect(await donations.processedTx(DUMMY_TX)).to.equal(true);
+    });
+  });
+});

--- a/test/Donations.spec.ts
+++ b/test/Donations.spec.ts
@@ -111,8 +111,8 @@ describe("Donations", () => {
       ]);
 
       // burn donations
-      await donations.connect(alice).burn(0);
       await donations.connect(alice).burn(1);
+      await donations.connect(alice).burn(2);
 
       // donate
       await donations.donate(CHARITY_ID, underlying.address, bob.address);
@@ -137,7 +137,7 @@ describe("Donations", () => {
       ]);
 
       // burn donations
-      await donations.connect(alice).burn(0);
+      await donations.connect(alice).burn(1);
 
       // donate
       await donations.donate(CHARITY_ID, underlying.address, bob.address);
@@ -164,7 +164,7 @@ describe("Donations", () => {
       ]);
 
       // burn donations
-      await donations.connect(alice).burn(0);
+      await donations.connect(alice).burn(1);
 
       const tx = donations.donate(CHARITY_ID, underlying.address, bob.address);
 
@@ -203,7 +203,7 @@ describe("Donations", () => {
         await donations.transferableAmounts(underlying.address, CHARITY_ID)
       ).to.equal(0);
 
-      await donations.connect(alice).burn(0);
+      await donations.connect(alice).burn(1);
 
       expect(
         await donations.transferableAmounts(underlying.address, CHARITY_ID)
@@ -220,7 +220,7 @@ describe("Donations", () => {
         }),
       ]);
 
-      await donations.connect(alice).burn(0);
+      await donations.connect(alice).burn(1);
 
       expect(
         await donations.transferableAmounts(underlying.address, CHARITY_ID)
@@ -242,7 +242,7 @@ describe("Donations", () => {
 
       await moveForwardTwoWeeks();
 
-      await donations.connect(owner).burn(0);
+      await donations.connect(owner).burn(1);
 
       expect(
         await donations.transferableAmounts(underlying.address, CHARITY_ID)
@@ -264,7 +264,7 @@ describe("Donations", () => {
 
       await moveForwardTwoWeeks();
 
-      await expect(donations.connect(owner).burn(0)).to.be.revertedWith(
+      await expect(donations.connect(owner).burn(1)).to.be.revertedWith(
         "Donations: not allowed"
       );
     });
@@ -279,9 +279,9 @@ describe("Donations", () => {
         }),
       ]);
 
-      const tx = donations.connect(alice).burn(0);
+      const tx = donations.connect(alice).burn(1);
 
-      await expect(tx).to.emit(donations, "DonationBurned").withArgs(0);
+      await expect(tx).to.emit(donations, "DonationBurned").withArgs(1);
     });
 
     it("fails if the caller is not the owner nor the admin", async () => {
@@ -294,7 +294,7 @@ describe("Donations", () => {
         }),
       ]);
 
-      await expect(donations.connect(bob).burn(0)).to.be.revertedWith(
+      await expect(donations.connect(bob).burn(1)).to.be.revertedWith(
         "Donations: not allowed"
       );
     });
@@ -309,10 +309,10 @@ describe("Donations", () => {
         donationParams.build(),
       ]);
 
-      expect(await donations.metadata(0)).to.be.ok;
       expect(await donations.metadata(1)).to.be.ok;
       expect(await donations.metadata(2)).to.be.ok;
       expect(await donations.metadata(3)).to.be.ok;
+      expect(await donations.metadata(4)).to.be.ok;
     });
 
     it("mints the correct NFT", async () => {
@@ -325,9 +325,9 @@ describe("Donations", () => {
         }),
       ]);
 
-      expect(await donations.ownerOf(0)).to.equal(owner.address);
+      expect(await donations.ownerOf(1)).to.equal(owner.address);
 
-      const donation = await donations.metadata(0);
+      const donation = await donations.metadata(1);
 
       expect(donation.amount).to.equal(parseUnits("1"));
       expect(donation.destinationId).to.equal(CHARITY_ID);
@@ -369,7 +369,7 @@ describe("Donations", () => {
       await expect(tx)
         .to.emit(donations, "DonationMinted")
         .withArgs(
-          0,
+          1,
           CHARITY_ID,
           groupId,
           underlying.address,

--- a/test/Donations.spec.ts
+++ b/test/Donations.spec.ts
@@ -2,7 +2,7 @@ import type { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 import { ethers } from "hardhat";
 import { expect } from "chai";
 import { time } from "@openzeppelin/test-helpers";
-import { BigNumber, utils } from "ethers";
+import { BigNumber, constants, utils } from "ethers";
 
 import type { Donations } from "../typechain";
 import { MockDAI, MockDAI__factory } from "../typechain";
@@ -40,6 +40,25 @@ describe("Donations", () => {
     donations = (await Donations.deploy(owner.address)) as Donations;
     WORKER_ROLE = await donations.WORKER_ROLE();
     DEFAULT_ADMIN_ROLE = await donations.DEFAULT_ADMIN_ROLE();
+  });
+
+  describe("constructor", () => {
+    it("it reverts if owner is address(0)", async () => {
+      const Donations = await ethers.getContractFactory("Donations");
+
+      await expect(Donations.deploy(constants.AddressZero)).to.be.revertedWith(
+        "Vault: owner cannot be 0x0"
+      );
+    });
+
+    it("sets the initial state", async () => {
+      expect(
+        await donations.hasRole(DEFAULT_ADMIN_ROLE, owner.address)
+      ).to.be.equal(true);
+      expect(await donations.hasRole(WORKER_ROLE, owner.address)).to.be.equal(
+        true
+      );
+    });
   });
 
   describe("setTTL", () => {

--- a/test/Donations.spec.ts
+++ b/test/Donations.spec.ts
@@ -42,6 +42,16 @@ describe("Donations", () => {
     DEFAULT_ADMIN_ROLE = await donations.DEFAULT_ADMIN_ROLE();
   });
 
+  describe("supportsInterface", () => {
+    it("supprots the ERC721 interface", async () => {
+      expect(await donations.supportsInterface("0x80ac58cd")).to.eq(true);
+    });
+
+    it("supprots the AccessControl interface", async () => {
+      expect(await donations.supportsInterface("0x7965db0b")).to.eq(true);
+    });
+  });
+
   describe("constructor", () => {
     it("it reverts if owner is address(0)", async () => {
       const Donations = await ethers.getContractFactory("Donations");

--- a/test/Donations.spec.ts
+++ b/test/Donations.spec.ts
@@ -5,7 +5,7 @@ import { time } from "@openzeppelin/test-helpers";
 import { BigNumber, constants, utils } from "ethers";
 
 import type { Donations } from "../typechain";
-import { MockDAI, MockDAI__factory } from "../typechain";
+import { MockDAI } from "../typechain";
 import { donationParams } from "./shared/factories";
 import {
   getLastBlockTimestamp,

--- a/test/Donations.spec.ts
+++ b/test/Donations.spec.ts
@@ -315,7 +315,10 @@ describe("Donations", () => {
       expect(await donations.metadata(4)).to.be.ok;
     });
 
-    it("mints the correct NFT", async () => {
+    it.only("mints the correct NFT", async () => {
+      const ttl = BigNumber.from(time.duration.days(180).toNumber());
+      await donations.setTTL(ttl);
+
       await donations.mint(DUMMY_TX, 0, [
         donationParams.build({
           destinationId: CHARITY_ID,
@@ -328,10 +331,12 @@ describe("Donations", () => {
       expect(await donations.ownerOf(1)).to.equal(owner.address);
 
       const donation = await donations.metadata(1);
+      const expiry = ttl.add(await getLastBlockTimestamp());
 
       expect(donation.amount).to.equal(parseUnits("1"));
       expect(donation.destinationId).to.equal(CHARITY_ID);
       expect(donation.token).to.equal(underlying.address);
+      expect(donation.expiry).to.equal(expiry);
     });
 
     it("marks the donations group as processed", async () => {

--- a/test/Donations.spec.ts
+++ b/test/Donations.spec.ts
@@ -315,7 +315,7 @@ describe("Donations", () => {
       expect(donation.token).to.equal(underlying.address);
     });
 
-    it.only("marks the donations group as processed", async () => {
+    it("marks the donations group as processed", async () => {
       await donations.mint(DUMMY_TX, 0, [donationParams.build()]);
 
       const groupId = utils.solidityKeccak256(
@@ -342,12 +342,17 @@ describe("Donations", () => {
 
       const expiry = ttl.add(await getLastBlockTimestamp()).add(1);
 
+      const groupId = utils.solidityKeccak256(
+        ["bytes32", "uint256"],
+        [DUMMY_TX, 0]
+      );
+
       await expect(tx)
         .to.emit(donations, "DonationMinted")
         .withArgs(
           0,
           CHARITY_ID,
-          DUMMY_TX,
+          groupId,
           underlying.address,
           expiry,
           parseUnits("1"),

--- a/test/shared/factories/donationParams.ts
+++ b/test/shared/factories/donationParams.ts
@@ -1,0 +1,21 @@
+import { BigNumberish } from "ethers";
+import { Factory } from "fishery";
+import { ethers } from "ethers";
+
+const { parseUnits } = ethers.utils;
+
+interface DonationParams {
+  amount: BigNumberish;
+  destinationId: BigNumberish;
+  owner: string;
+  token: string;
+}
+
+export const donationParams = Factory.define<DonationParams>(() => {
+  return {
+    amount: parseUnits("1"),
+    destinationId: parseUnits("1"),
+    owner: "0x000000000000000000000000000000000000dEaD",
+    token: "0x000000000000000000000000000000000000dEaD",
+  };
+});

--- a/test/shared/factories/index.ts
+++ b/test/shared/factories/index.ts
@@ -1,2 +1,3 @@
 export { claimParams } from "./claimParams";
 export { depositParams } from "./depositParams";
+export { donationParams } from "./donationParams";


### PR DESCRIPTION
This contract is the last step before the donated funds are sent to the charities. This contract will receive the donations claimed by the treasury and store an NFT for every donation. This contract will be deployed to Polygon, and the funds will have to be bridged by the backend. The backend will also be in charge of minting the NFTs for everyone. 

The variable `_donationsId` in the mint function is used for transparency and the backend from creating more NFTs than it's supposed to. The idea is for this variable to be the tx hash where the treasury claimed the funds on Ethereum. You can look up the transaction and make sure the backend behaves as expected. 

On the `donate` function, the `_to` param is provided by TheGivingBlock. Each charity will have more than one address once we have non-anonymous donations.