### PR TITLE
Subgraph updates

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       postgres_pass: let-me-in
       postgres_db: graph-node
       ipfs: ipfs:5001
-      ethereum: "${ETHEREUM_RPC:-mainnet:http://ethereum:8545}"
+      ethereum: "${ETHEREUM_RPC:-mainnet:http://172.17.0.1:8545}"
       RUST_LOG: info
       GRAPH_LOG: debug
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     depends_on:
       - postgres
       - ipfs
-      - ethereum
+      # - ethereum
     environment:
       postgres_host: postgres
       postgres_user: graph-node
@@ -43,12 +43,12 @@ services:
     ports:
       - "5001:5001"
 
-  ethereum:
-    build:
-      context: .
-      dockerfile: docker/ganache.Dockerfile
-    restart: unless-stopped
-    environment:
-      MNEMONIC: '${MNEMONIC:-"core tornado motion pigeon kiss dish differ asthma much ritual black foil"}'
-    ports:
-      - "8545:8545"
+  # ethereum:
+  #   build:
+  #     context: .
+  #     dockerfile: docker/ganache.Dockerfile
+  #   restart: unless-stopped
+  #   environment:
+  #     MNEMONIC: '${MNEMONIC:-"core tornado motion pigeon kiss dish differ asthma much ritual black foil"}'
+  #   ports:
+  #     - "8545:8545"

--- a/subgraph/config/hardhat.json
+++ b/subgraph/config/hardhat.json
@@ -1,8 +1,17 @@
 {
   "vaults": [
-    { "address": "0x9f620D84E77DB85A7Cae9F60a2EB60B265518707" },
-    { "address": "0xF0C57819803C04e3b061C64713eCd856AC35B4c4" },
-    { "address": "0x9119f0F35e7D05Dde778A69A26cEf2330a5e70F9" }
+    {
+      "name": "DAI_Vault",
+      "address": "0x9f620D84E77DB85A7Cae9F60a2EB60B265518707"
+    },
+    {
+      "name": "USDC_Vault",
+      "address": "0xF0C57819803C04e3b061C64713eCd856AC35B4c4"
+    },
+    {
+      "name": "UST_Vault",
+      "address": "0x9119f0F35e7D05Dde778A69A26cEf2330a5e70F9"
+    }
   ],
   "claimers": []
 }

--- a/subgraph/config/hardhat.json
+++ b/subgraph/config/hardhat.json
@@ -1,0 +1,8 @@
+{
+  "vaults": [
+    { "address": "0x9f620D84E77DB85A7Cae9F60a2EB60B265518707" },
+    { "address": "0xF0C57819803C04e3b061C64713eCd856AC35B4c4" },
+    { "address": "0x9119f0F35e7D05Dde778A69A26cEf2330a5e70F9" }
+  ],
+  "claimers": []
+}

--- a/subgraph/package.json
+++ b/subgraph/package.json
@@ -10,8 +10,8 @@
     "deploy-local": "graph deploy --node http://localhost:8020/ --ipfs http://localhost:5001 sandclock-eth",
     "all-local": "yarn codegen && yarn create-local && yarn deploy-local --version-label v0.0.1",
     "test": "graph test",
-    "prep:hardhat": "mustache configs/hardhat.json subgraph.template.yml > subgraph.yml",
-    "deploy:hardhat": "yarn prep:hardhat && yarn build && yarn deploy-local"
+    "prep:hardhat": "mustache ./config/hardhat.json subgraph.template.yaml > subgraph.yaml",
+    "deploy:hardhat": "yarn build && yarn codegen && yarn create-local && yarn deploy-local --version-label v0.0.1"
   },
   "dependencies": {
     "@graphprotocol/graph-cli": "0.25.1",

--- a/subgraph/package.json
+++ b/subgraph/package.json
@@ -9,12 +9,15 @@
     "remove-local": "graph remove --node http://localhost:8020/ sandclock-eth",
     "deploy-local": "graph deploy --node http://localhost:8020/ --ipfs http://localhost:5001 sandclock-eth",
     "all-local": "yarn codegen && yarn create-local && yarn deploy-local --version-label v0.0.1",
-    "test": "graph test"
+    "test": "graph test",
+    "prep:hardhat": "mustache configs/hardhat.json subgraph.template.yml > subgraph.yml",
+    "deploy:hardhat": "yarn prep:hardhat && yarn build && yarn deploy-local"
   },
   "dependencies": {
     "@graphprotocol/graph-cli": "0.25.1",
     "@graphprotocol/graph-ts": "0.24.1",
-    "matchstick-as": "^0.3.0"
+    "matchstick-as": "^0.3.0",
+    "mustache": "^4.2.0"
   },
   "devDependencies": {}
 }

--- a/subgraph/src/mappings/vault.ts
+++ b/subgraph/src/mappings/vault.ts
@@ -3,25 +3,22 @@ import {
   BigInt,
   ByteArray,
   log,
-  Bytes
+  Bytes,
 } from "@graphprotocol/graph-ts";
 import {
   DepositBurned,
   DepositMinted,
   YieldClaimed,
-  TreasuryUpdated
-} from "../types/templates/Vault/IVault";
-import {
-  Sponsored,
-  Unsponsored
-} from "../types/templates/Vault/IVaultSponsoring";
+  TreasuryUpdated,
+} from "../types/DAI_Vault/IVault";
+import { Sponsored, Unsponsored } from "../types/DAI_Vault/IVaultSponsoring";
 import {
   Sponsor,
   Claimer,
   Deposit,
   Foundation,
   Vault,
-  Donation
+  Donation,
 } from "../types/schema";
 
 export function handleYieldClaimed(event: YieldClaimed): void {

--- a/subgraph/subgraph.template.yaml
+++ b/subgraph/subgraph.template.yaml
@@ -2,35 +2,13 @@ specVersion: 0.0.2
 schema:
   file: ./schema.graphql
 dataSources:
-  - name: SandclockFactory
-    kind: ethereum/contract
-    network: mainnet
-    source:
-      address: "0x9ce37148F5E347E55857C22c012B0741e4733130"
-      abi: SandclockFactory
-    mapping:
-      kind: ethereum/events
-      apiVersion: 0.0.6
-      language: wasm/assemblyscript
-      file: ./src/mappings/factory.ts
-      entities:
-        - Factory
-        - Vault
-      abis:
-        - name: SandclockFactory
-          file: ../artifacts/contracts/SandclockFactory.sol/SandclockFactory.json
-        - name: Vault
-          file: ../artifacts/contracts/Vault.sol/Vault.json
-      eventHandlers:
-        - event: NewVault(indexed address,uint256)
-          handler: handleNewVault
-
-templates:
+{{#vaults}}
   - name: Vault
     kind: ethereum/contract
     network: mainnet
     source:
       abi: Vault
+      address: "{{vaultAddr}}"
     mapping: &mapping
       kind: ethereum/events
       apiVersion: 0.0.6
@@ -59,12 +37,14 @@ templates:
           handler: handleYieldClaimed
         - event: TreasuryUpdated(indexed address)
           handler: handleTreasuryUpdated
-
+{{/vaults}}
+{{#claimers}}
   - name: Claimers
     kind: ethereum/contract
     network: mainnet
     source:
       abi: IClaimers
+      address: "{{claimersAddr}}"
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.6
@@ -80,3 +60,4 @@ templates:
       eventHandlers:
         - event: Transfer(indexed address,indexed address,indexed uint256)
           handler: handleClaimerTransfer
+{{/claimers}}

--- a/subgraph/subgraph.yaml
+++ b/subgraph/subgraph.yaml
@@ -2,13 +2,12 @@ specVersion: 0.0.2
 schema:
   file: ./schema.graphql
 dataSources:
-{{#vaults}}
   - name: Vault
     kind: ethereum/contract
     network: mainnet
     source:
       abi: Vault
-      address: "{{vaultAddr}}"
+      address: "0x9f620D84E77DB85A7Cae9F60a2EB60B265518707"
     mapping: &mapping
       kind: ethereum/events
       apiVersion: 0.0.6
@@ -25,7 +24,7 @@ dataSources:
         - name: IVaultSponsoring
           file: ../artifacts/contracts/vault/IVaultSponsoring.sol/IVaultSponsoring.json
       eventHandlers:
-        - event: DepositMinted(indexed uint256,uint256,uint256,uint256,indexed address,indexed address,uint256,uint256,bytes)
+        - event: DepositMinted(indexed uint256,uint256,uint256,uint256,indexed address,indexed address,uint256,uint64,bytes)
           handler: handleDepositMinted
         - event: DepositBurned(indexed uint256,uint256,indexed address)
           handler: handleDepositBurned
@@ -33,31 +32,7 @@ dataSources:
           handler: handleSponsored
         - event: Unsponsored(indexed uint256)
           handler: handleUnsponsored
-        - event: YieldClaimed(uint256,indexed address,uint256,uint256)
+        - event: YieldClaimed(uint256,indexed address,uint256,uint256,uint256)
           handler: handleYieldClaimed
         - event: TreasuryUpdated(indexed address)
           handler: handleTreasuryUpdated
-{{/vaults}}
-{{#claimers}}
-  - name: Claimers
-    kind: ethereum/contract
-    network: mainnet
-    source:
-      abi: IClaimers
-      address: "{{claimersAddr}}"
-    mapping:
-      kind: ethereum/events
-      apiVersion: 0.0.6
-      language: wasm/assemblyscript
-      file: ./src/mappings/claimers.ts
-      entities:
-        - Claimers
-      abis:
-        - name: IClaimers
-          file: ../artifacts/contracts/vault/IClaimers.sol/IClaimers.json
-        - name: IERC721
-          file: ../artifacts/@openzeppelin/contracts/token/ERC721/IERC721.sol/IERC721.json
-      eventHandlers:
-        - event: Transfer(indexed address,indexed address,indexed uint256)
-          handler: handleClaimerTransfer
-{{/claimers}}

--- a/subgraph/yarn.lock
+++ b/subgraph/yarn.lock
@@ -2050,6 +2050,11 @@ murmurhash3js@^3.0.1:
   resolved "https://registry.yarnpkg.com/murmurhash3js/-/murmurhash3js-3.0.1.tgz#3e983e5b47c2a06f43a713174e7e435ca044b998"
   integrity sha1-Ppg+W0fCoG9DpxMXTn5DXKBEuZg=
 
+mustache@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/mustache/-/mustache-4.2.0.tgz#e5892324d60a12ec9c2a73359edca52972bf6f64"
+  integrity sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==
+
 mute-stream@0.0.8:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"


### PR DESCRIPTION
I was working on this yesterday/today, also with @0xrin1 's help.
There are a few things we need to discuss though:

apparently, the approach without a Factory contract doesn't exactly work as expected. The reason is that we can't just create 3 entities with the same name `Vault`. Compilation fails. As a result, the only solution would be to name them DAI_Vault / UST_Vault, etc. which means we get individual typings for each vault, even though they look the same

Another matter is that we're never actually instantiating the vault instance on graph. So calling `Vault.load(vaultaddr)` will fail. The hotfix would be to do a `createVaultIfNotExists()` on every single vault handler, which is awkward

Another potential solution is to go back 50%: we still don't use a factory, but we can still have a Registry contract, where we emit events for every new deployed vault, allowing the previous subgraph approach with templates to work without overcomplicating the deploy flow

---

This current Draft is still refactoring the graph to not use templates. It's just the pending work I had from today while working with Martin. Depending on the result of this discussion, we may proceed with this or just scratch this branch