### PR TITLE
Remove IClaimers

### DIFF
--- a/contracts/vault/Claimers.sol
+++ b/contracts/vault/Claimers.sol
@@ -5,10 +5,9 @@ import {ERC721} from "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import {Counters} from "@openzeppelin/contracts/utils/Counters.sol";
 
-import {IClaimers} from "./IClaimers.sol";
 import {IVault} from "../vault/IVault.sol";
 
-contract Claimers is ERC721, IClaimers {
+contract Claimers is ERC721 {
     using Counters for Counters.Counter;
 
     Counters.Counter private _tokenIds;

--- a/contracts/vault/IClaimers.sol
+++ b/contracts/vault/IClaimers.sol
@@ -1,7 +1,0 @@
-// SPDX-License-Identifier: UNLICENSED
-pragma solidity =0.8.10;
-
-import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
-
-
-interface IClaimers is IERC721 {}


### PR DESCRIPTION
IClaimers seems to not be in use. In order to increase readibliity and avoid ambiguity/shadowing which could lead to [inheritance issues](https://docs.soliditylang.org/en/v0.8.13/contracts.html#multiple-inheritance-and-linearization). Lets just remove it?

⚠️ I don't know what to do about [this part](https://github.com/lindy-labs/sc_solidity-contracts/blob/ff18a7945f7c525658aeb102f28064f0ff6e242f/subgraph/subgraph.yaml#L76). Please provide input.