### PR TITLE
Add coveralls coverage monitoring

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,41 @@
+name: Test Coverage
+
+# Controls when the workflow will run
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - '*'
+  pull_request:
+    branches: [ main ]
+    types: [opened, synchronize]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    env:
+      ALCHEMY_API_ENDPOINT: ${{ secrets.ALCHEMY_API_ENDPOINT }}
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '16'
+          cache: 'yarn'
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+
+      - run: yarn install
+      - run: yarn compile
+      - run: yarn coverage
+
+      - name: Coveralls
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.solcover.js
+++ b/.solcover.js
@@ -1,3 +1,3 @@
 module.exports = {
-  skipFiles: ["mock/", "interfaces/"],
+  skipFiles: ["mock/", "interfaces/", "test/", "echidna/"],
 };

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Sandclock's Solidity Monorepo
 
+![Build Status](https://github.com/lindy-labs/sc_solidity-contracts/workflows/CI/badge.svg)
+[![Coverage Status](https://coveralls.io/repos/github/lindy-labs/sc_solidity-contracts/badge.svg)](https://coveralls.io/github/lindy-labs/sc_solidity-contracts)
+
 Solidity implementation of [Sandclock]'s vaults, strategies, and peripheral contracts.
 
 ## Contracts


### PR DESCRIPTION
Running seperately for the following reason:
- "It's best practice to run coverage as a separate CI job rather than assume its equivalence to test. Coverage uses block gas settings far above the network limits, ignores [EIP 170](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-170.md) and rewrites your contracts in ways that might affect their behavior."