### PR TITLE
Add `idx` to InitRedeemStable Event

### DIFF
--- a/contracts/strategy/anchor/AnchorBaseStrategy.sol
+++ b/contracts/strategy/anchor/AnchorBaseStrategy.sol
@@ -32,7 +32,11 @@ abstract contract AnchorBaseStrategy is IStrategy, AccessControl {
         uint256 ustAmount,
         uint256 aUstAmount
     );
-    event InitRedeemStable(address indexed operator, uint256 aUstAmount);
+    event InitRedeemStable(
+        address indexed operator,
+        uint256 indexed idx,
+        uint256 aUstAmount
+    );
     event FinishRedeemStable(
         address indexed operator,
         uint256 aUstAmount,
@@ -241,7 +245,7 @@ abstract contract AnchorBaseStrategy is IStrategy, AccessControl {
 
         redeemOperations.push(Operation({operator: operator, amount: amount}));
 
-        emit InitRedeemStable(operator, amount);
+        emit InitRedeemStable(operator, redeemOperations.length - 1, amount);
     }
 
     /**

--- a/contracts/strategy/anchor/AnchorBaseStrategy.sol
+++ b/contracts/strategy/anchor/AnchorBaseStrategy.sol
@@ -32,6 +32,7 @@ abstract contract AnchorBaseStrategy is IStrategy, AccessControl {
         uint256 ustAmount,
         uint256 aUstAmount
     );
+    event RearrangeDepositOperation(uint256 indexed from, uint256 indexed to);
     event InitRedeemStable(
         address indexed operator,
         uint256 indexed idx,
@@ -43,6 +44,7 @@ abstract contract AnchorBaseStrategy is IStrategy, AccessControl {
         uint256 ustAmount,
         uint256 underlyingAmount
     );
+    event RearrangeRedeemOperation(uint256 indexed from, uint256 indexed to);
 
     struct Operation {
         address operator;
@@ -222,6 +224,8 @@ abstract contract AnchorBaseStrategy is IStrategy, AccessControl {
             operation.amount = lastOperation.amount;
         }
 
+        emit RearrangeDepositOperation(depositOperations.length - 1, idx);
+
         depositOperations.pop();
     }
 
@@ -342,6 +346,9 @@ abstract contract AnchorBaseStrategy is IStrategy, AccessControl {
             operation.operator = lastOperation.operator;
             operation.amount = lastOperation.amount;
         }
+
+        emit RearrangeRedeemOperation(redeemOperations.length - 1, idx);
+
         redeemOperations.pop();
 
         return (operator, operationAmount, redeemedAmount);

--- a/contracts/strategy/anchor/AnchorBaseStrategy.sol
+++ b/contracts/strategy/anchor/AnchorBaseStrategy.sol
@@ -222,9 +222,9 @@ abstract contract AnchorBaseStrategy is IStrategy, AccessControl {
             ];
             operation.operator = lastOperation.operator;
             operation.amount = lastOperation.amount;
-        }
 
-        emit RearrangeDepositOperation(depositOperations.length - 1, idx);
+            emit RearrangeDepositOperation(depositOperations.length - 1, idx);
+        }
 
         depositOperations.pop();
     }
@@ -345,9 +345,9 @@ abstract contract AnchorBaseStrategy is IStrategy, AccessControl {
             ];
             operation.operator = lastOperation.operator;
             operation.amount = lastOperation.amount;
-        }
 
-        emit RearrangeRedeemOperation(redeemOperations.length - 1, idx);
+            emit RearrangeRedeemOperation(redeemOperations.length - 1, idx);
+        }
 
         redeemOperations.pop();
 

--- a/test/strategy/anchor/AnchorUSTStrategy.spec.ts
+++ b/test/strategy/anchor/AnchorUSTStrategy.spec.ts
@@ -487,7 +487,7 @@ describe("AnchorUSTStrategy", () => {
 
       await expect(tx)
         .to.emit(strategy, "InitRedeemStable")
-        .withArgs(operator, redeemAmount);
+        .withArgs(operator, 0, redeemAmount);
     });
 
     it("Should be able to init redeem several times", async () => {
@@ -708,7 +708,7 @@ describe("AnchorUSTStrategy", () => {
 
       await expect(tx)
         .to.emit(strategy, "InitRedeemStable")
-        .withArgs(operator, aUstAmount0);
+        .withArgs(operator, 0, aUstAmount0);
     });
   });
 

--- a/test/strategy/anchor/AnchorUSTStrategy.spec.ts
+++ b/test/strategy/anchor/AnchorUSTStrategy.spec.ts
@@ -433,6 +433,35 @@ describe("AnchorUSTStrategy", () => {
       expect(operation0.operator).equal(operator1);
       expect(operation0.amount).equal(investAmount1);
     });
+
+    it("Should rearrange deposit operations when not finalizing last in array", async () => {
+      let aUstRate = utils.parseEther("1.1");
+      await setAUstRate(aUstRate);
+
+      await notifyDepositReturnAmount(operator0, aUstAmount0);
+
+      const underlyingAmount1 = utils.parseUnits("100", 18);
+      const aUstAmount1 = utils.parseUnits("80", 18);
+
+      const operator1 = await registerNewTestOperator();
+
+      await depositVault(underlyingAmount1);
+      await vault.connect(owner).updateInvested("0x");
+
+      await notifyDepositReturnAmount(operator1, aUstAmount1);
+
+      const tx = await strategy.connect(manager).finishDepositStable(0);
+
+      expect(await strategy.depositOperationLength()).equal(1);
+
+      await expect(tx)
+        .to.emit(strategy, "RearrangeDepositOperation")
+        .withArgs(1, 0);
+
+      await expect(tx)
+        .to.emit(strategy, "FinishDepositStable")
+        .withArgs(operator0, investAmount0, aUstAmount0);
+    });
   });
 
   describe("#initRedeemStable function", () => {
@@ -666,6 +695,46 @@ describe("AnchorUSTStrategy", () => {
       );
 
       expect(await strategy.redeemOperationLength()).equal(0);
+    });
+
+    it("Should rearrange redeem operations when not finalizing last in array", async () => {
+      let aUstRate = utils.parseEther("1.1");
+      await setAUstRate(aUstRate);
+
+      let redeemedUSTAmount0 = utils.parseUnits("55", 18);
+      await notifyRedeemReturnAmount(operator0, redeemedUSTAmount0);
+
+      const underlyingAmount1 = utils.parseUnits("100", 18);
+      const aUstAmount1 = utils.parseUnits("80", 18);
+      const operator1 = await registerNewTestOperator();
+      await depositVault(underlyingAmount1);
+      await vault.connect(owner).updateInvested("0x");
+
+      await notifyDepositReturnAmount(operator1, aUstAmount1);
+      await strategy.connect(manager).finishDepositStable(0);
+
+      const operator2 = await registerNewTestOperator();
+
+      await strategy.connect(manager).initRedeemStable(redeemAmount0);
+
+      await notifyRedeemReturnAmount(operator2, redeemedUSTAmount0);
+
+      const tx = await strategy.connect(manager).finishRedeemStable(0);
+
+      expect(await strategy.redeemOperationLength()).equal(1);
+
+      await expect(tx)
+        .to.emit(strategy, "RearrangeRedeemOperation")
+        .withArgs(1, 0);
+
+      await expect(tx)
+        .to.emit(strategy, "FinishRedeemStable")
+        .withArgs(
+          operator0,
+          redeemAmount0,
+          redeemedUSTAmount0,
+          redeemedUSTAmount0
+        );
     });
   });
 


### PR DESCRIPTION
- Adds `uint256 indexed idx` to `InitRedeemStable` event emission
- Adjusts existing tests accordingly
- Introduce `RearrangeDepositOperation` and `RearrangeRedeemOperation` events