### PR TITLE
Add Owner and CreatedAt fields to Foundation

### DIFF
--- a/subgraph/schema.graphql
+++ b/subgraph/schema.graphql
@@ -11,6 +11,8 @@ type Foundation @entity {
   id: ID!
   vault: Vault!
   deposits: [Deposit!]! @derivedFrom(field: "foundation")
+  owner: Bytes!
+  createdAt: BigInt
 }
 
 type Deposit @entity {

--- a/subgraph/src/mappings/vault.ts
+++ b/subgraph/src/mappings/vault.ts
@@ -103,8 +103,14 @@ export function handleDepositMinted(event: DepositMinted): void {
     claimer.depositsIds = [];
   }
 
-  const foundation = new Foundation(foundationId);
-  foundation.vault = vaultId;
+  let foundation = Foundation.load(foundationId);
+  if (foundation == null) {
+    foundation = new Foundation(foundationId);
+
+    foundation.vault = vaultId;
+    foundation.owner = event.params.depositor;
+    foundation.createdAt = event.block.timestamp;
+  }
 
   claimer.principal = claimer.principal.plus(event.params.amount);
   claimer.shares = claimer.shares.plus(event.params.shares);


### PR DESCRIPTION
This PR adds `owner` and `createdAt` fields to the Foundation entity.
These are simple fields because they don't require any changes to either the smart contracts or the events to be emitted.