### PR TITLE
Renames Perc to Pct

### DIFF
--- a/contracts/Vault.sol
+++ b/contracts/Vault.sol
@@ -67,7 +67,7 @@ contract Vault is
     IERC20 public override(IVault) underlying;
 
     /// @inheritdoc IVault
-    uint16 public override(IVault) investPerc;
+    uint16 public override(IVault) investPct;
 
     /// @inheritdoc IVault
     uint64 public immutable override(IVault) minLockPeriod;
@@ -114,7 +114,7 @@ contract Vault is
     /**
      * @param _underlying Underlying ERC20 token to use.
      * @param _minLockPeriod Minimum lock period to deposit
-     * @param _investPerc Percentage of the total underlying to invest in the strategy
+     * @param _investPct Percentage of the total underlying to invest in the strategy
      * @param _treasury Treasury address to collect performance fee
      * @param _owner Vault admin address
      * @param _perfFeePct Performance fee percentage
@@ -124,17 +124,17 @@ contract Vault is
     constructor(
         IERC20 _underlying,
         uint64 _minLockPeriod,
-        uint16 _investPerc,
+        uint16 _investPct,
         address _treasury,
         address _owner,
         uint16 _perfFeePct,
         uint16 _investmentFeeEstimatePct,
         SwapPoolParam[] memory _swapPools
     ) {
-        require(_investPerc.validPerc(), "Vault: invalid investPerc");
-        require(_perfFeePct.validPerc(), "Vault: invalid performance fee");
+        require(_investPct.validPct(), "Vault: invalid investPct");
+        require(_perfFeePct.validPct(), "Vault: invalid performance fee");
         require(
-            _investmentFeeEstimatePct.validPerc(),
+            _investmentFeeEstimatePct.validPct(),
             "Vault: invalid investment fee"
         );
         require(
@@ -152,7 +152,7 @@ contract Vault is
         _setupRole(INVESTOR_ROLE, _owner);
         _setupRole(SETTINGS_ROLE, _owner);
 
-        investPerc = _investPerc;
+        investPct = _investPct;
         underlying = _underlying;
         treasury = _treasury;
         minLockPeriod = _minLockPeriod;
@@ -217,7 +217,7 @@ contract Vault is
             totalUnderlyingMinusSponsored()
         );
 
-        perfFee = sharesAmount.percOf(perfFeePct);
+        perfFee = sharesAmount.pctOf(perfFeePct);
         claimableYield = sharesAmount - perfFee;
     }
 
@@ -304,7 +304,7 @@ contract Vault is
     }
 
     function investableAmount() public view returns (uint256) {
-        uint256 maxInvestableAssets = totalUnderlying().percOf(investPerc);
+        uint256 maxInvestableAssets = totalUnderlying().pctOf(investPct);
 
         uint256 alreadyInvested = strategy.investedAssets();
 
@@ -428,16 +428,16 @@ contract Vault is
     //
 
     /// @inheritdoc IVaultSettings
-    function setInvestPerc(uint16 _investPct)
+    function setInvestPct(uint16 _investPct)
         external
         override(IVaultSettings)
         onlyRole(SETTINGS_ROLE)
     {
-        require(PercentMath.validPerc(_investPct), "Vault: invalid investPerc");
+        require(PercentMath.validPct(_investPct), "Vault: invalid investPct");
 
         emit InvestPctUpdated(_investPct);
 
-        investPerc = _investPct;
+        investPct = _investPct;
     }
 
     /// @inheritdoc IVaultSettings
@@ -461,7 +461,7 @@ contract Vault is
         onlyRole(SETTINGS_ROLE)
     {
         require(
-            PercentMath.validPerc(_perfFeePct),
+            PercentMath.validPct(_perfFeePct),
             "Vault: invalid performance fee"
         );
         perfFeePct = _perfFeePct;
@@ -495,7 +495,7 @@ contract Vault is
         override(IVaultSettings)
         onlyRole(SETTINGS_ROLE)
     {
-        require(pct.validPerc(), "Vault: invalid investment fee");
+        require(pct.validPct(), "Vault: invalid investment fee");
 
         investmentFeeEstimatePct = pct;
         emit InvestmentFeeEstimatePctUpdated(pct);
@@ -674,7 +674,7 @@ contract Vault is
             // of relying on percentages
             uint256 localAmount = i == locals.claimsLen - 1
                 ? _amount - locals.accumulatedAmount
-                : _amount.percOf(data.pct);
+                : _amount.pctOf(data.pct);
 
             result[i] = _createClaim(
                 locals.groupId,
@@ -689,7 +689,7 @@ contract Vault is
         }
 
         require(
-            locals.accumulatedPct.is100Perc(),
+            locals.accumulatedPct.is100Pct(),
             "Vault: claims don't add up to 100%"
         );
 
@@ -912,7 +912,7 @@ contract Vault is
         view
         returns (uint256)
     {
-        return _amount - _amount.percOf(investmentFeeEstimatePct);
+        return _amount - _amount.pctOf(investmentFeeEstimatePct);
     }
 
     function sharesOf(uint256 claimerId) external view returns (uint256) {

--- a/contracts/lib/PercentMath.sol
+++ b/contracts/lib/PercentMath.sol
@@ -3,14 +3,14 @@ pragma solidity =0.8.10;
 
 library PercentMath {
     // Divisor used for representing percentages
-    uint256 public constant PERC_DIVISOR = 10000;
+    uint256 public constant PCT_DIVISOR = 10000;
 
     /**
-     * @dev Returns whether an amount is a valid percentage out of PERC_DIVISOR
+     * @dev Returns whether an amount is a valid percentage out of PCT_DIVISOR
      * @param _amount Amount that is supposed to be a percentage
      */
-    function validPerc(uint256 _amount) internal pure returns (bool) {
-        return _amount <= PERC_DIVISOR;
+    function validPct(uint256 _amount) internal pure returns (bool) {
+        return _amount <= PCT_DIVISOR;
     }
 
     /**
@@ -19,33 +19,33 @@ library PercentMath {
      * @param _fracNum Numerator of fraction representing the percentage
      * @param _fracDenom Denominator of fraction representing the percentage
      */
-    function percOf(
+    function pctOf(
         uint256 _amount,
         uint256 _fracNum,
         uint256 _fracDenom
     ) internal pure returns (uint256) {
-        return (_amount * percPoints(_fracNum, _fracDenom)) / PERC_DIVISOR;
+        return (_amount * pctPoints(_fracNum, _fracDenom)) / PCT_DIVISOR;
     }
 
     /**
-     * @dev Compute percentage of a value with the percentage represented by a fraction over PERC_DIVISOR
+     * @dev Compute percentage of a value with the percentage represented by a fraction over PCT_DIVISOR
      * @param _amount Amount to take the percentage of
-     * @param _fracNum Numerator of fraction representing the percentage with PERC_DIVISOR as the denominator
+     * @param _fracNum Numerator of fraction representing the percentage with PCT_DIVISOR as the denominator
      */
-    function percOf(uint256 _amount, uint16 _fracNum)
+    function pctOf(uint256 _amount, uint16 _fracNum)
         internal
         pure
         returns (uint256)
     {
-        return (_amount * _fracNum) / PERC_DIVISOR;
+        return (_amount * _fracNum) / PCT_DIVISOR;
     }
 
     /**
      * @dev Checks if a given number corresponds to 100%
-     * @param _perc Percentage value to check, with PERC_DIVISOR
+     * @param _perc Percentage value to check, with PCT_DIVISOR
      */
-    function is100Perc(uint256 _perc) internal pure returns (bool) {
-        return _perc == PERC_DIVISOR;
+    function is100Pct(uint256 _perc) internal pure returns (bool) {
+        return _perc == PCT_DIVISOR;
     }
 
     /**
@@ -53,11 +53,11 @@ library PercentMath {
      * @param _fracNum Numerator of fraction represeting the percentage
      * @param _fracDenom Denominator of fraction represeting the percentage
      */
-    function percPoints(uint256 _fracNum, uint256 _fracDenom)
+    function pctPoints(uint256 _fracNum, uint256 _fracDenom)
         internal
         pure
         returns (uint256)
     {
-        return (_fracNum * PERC_DIVISOR) / _fracDenom;
+        return (_fracNum * PCT_DIVISOR) / _fracDenom;
     }
 }

--- a/contracts/vault/IVault.sol
+++ b/contracts/vault/IVault.sol
@@ -86,7 +86,7 @@ interface IVault {
     /**
      * Percentage of the total underlying to invest in the strategy
      */
-    function investPerc() external view returns (uint16);
+    function investPct() external view returns (uint16);
 
     /**
      * Underlying ERC20 token accepted by the vault

--- a/contracts/vault/IVaultSettings.sol
+++ b/contracts/vault/IVaultSettings.sol
@@ -19,7 +19,7 @@ interface IVaultSettings {
      *
      * @param _investPct the new invest percentage
      */
-    function setInvestPerc(uint16 _investPct) external;
+    function setInvestPct(uint16 _investPct) external;
 
     /**
      * Changes the treasury used by the vault.

--- a/deploy/97_fixtureDeployments.ts
+++ b/deploy/97_fixtureDeployments.ts
@@ -58,9 +58,9 @@ const func = async function (env: HardhatRuntimeEnvironment) {
   const MANAGER_ROLE = utils.keccak256(utils.toUtf8Bytes("MANAGER_ROLE"));
   await anchorStrategy.connect(owner).grantRole(MANAGER_ROLE, owner.address);
 
-  console.log("Configuring vault strategy, treasury and investPerc");
+  console.log("Configuring vault strategy, treasury and investPct");
   await vault.connect(owner).setTreasury(treasury.address);
-  await vault.connect(owner).setInvestPerc("8000");
+  await vault.connect(owner).setInvestPct("8000");
   const setStrategyTx = await vault.setStrategy(anchorStrategy.address);
   await setStrategyTx.wait();
 };

--- a/test/Vault.spec.ts
+++ b/test/Vault.spec.ts
@@ -253,7 +253,7 @@ describe("Vault", () => {
           INVESTMENT_FEE_PCT,
           []
         )
-      ).to.be.revertedWith("Vault: invalid investPerc");
+      ).to.be.revertedWith("Vault: invalid investPct");
     });
 
     it("reverts if performance fee percentage is greater than 100%", async () => {
@@ -311,7 +311,7 @@ describe("Vault", () => {
 
       expect(await vault.underlying()).to.be.equal(underlying.address);
       expect(await vault.minLockPeriod()).to.be.equal(TWO_WEEKS);
-      expect(await vault.investPerc()).to.be.equal(INVEST_PCT);
+      expect(await vault.investPct()).to.be.equal(INVEST_PCT);
       expect(await vault.treasury()).to.be.equal(TREASURY);
       expect(await vault.perfFeePct()).to.be.equal(PERFORMANCE_FEE_PCT);
 
@@ -364,25 +364,25 @@ describe("Vault", () => {
     });
   });
 
-  describe("setInvestPerc", () => {
+  describe("setInvestPct", () => {
     it("reverts if msg.sender is not admin", async () => {
-      await expect(vault.connect(alice).setInvestPerc(100)).to.be.revertedWith(
+      await expect(vault.connect(alice).setInvestPct(100)).to.be.revertedWith(
         getRoleErrorMsg(alice, SETTINGS_ROLE)
       );
     });
 
     it("reverts if invest percentage is greater than 100%", async () => {
       await expect(
-        vault.connect(owner).setInvestPerc(DENOMINATOR.add(BigNumber.from("1")))
-      ).to.be.revertedWith("Vault: invalid investPerc");
+        vault.connect(owner).setInvestPct(DENOMINATOR.add(BigNumber.from("1")))
+      ).to.be.revertedWith("Vault: invalid investPct");
     });
 
-    it("change investPerc and emit InvestPercentageUpdated event", async () => {
+    it("change investPct and emit InvestPercentageUpdated event", async () => {
       const newInvestPct = 8000;
-      const tx = await vault.connect(owner).setInvestPerc(newInvestPct);
+      const tx = await vault.connect(owner).setInvestPct(newInvestPct);
 
       await expect(tx).emit(vault, "InvestPctUpdated").withArgs(newInvestPct);
-      expect(await vault.investPerc()).to.be.equal(newInvestPct);
+      expect(await vault.investPct()).to.be.equal(newInvestPct);
     });
   });
 
@@ -503,7 +503,7 @@ describe("Vault", () => {
 
     it("moves the funds to the strategy", async () => {
       await vault.connect(owner).setStrategy(strategy.address);
-      await vault.connect(owner).setInvestPerc("8000");
+      await vault.connect(owner).setInvestPct("8000");
       await addYieldToVault("100");
 
       await vault.connect(owner).updateInvested();
@@ -515,7 +515,7 @@ describe("Vault", () => {
 
     it("emits an event", async () => {
       await vault.connect(owner).setStrategy(strategy.address);
-      await vault.connect(owner).setInvestPerc("8000");
+      await vault.connect(owner).setInvestPct("8000");
       await addYieldToVault("100");
 
       const tx = await vault.connect(owner).updateInvested();
@@ -534,7 +534,7 @@ describe("Vault", () => {
 
     it("takes into account the invested amount", async () => {
       await vault.connect(owner).setStrategy(strategy.address);
-      await vault.connect(owner).setInvestPerc("9000");
+      await vault.connect(owner).setInvestPct("9000");
       await addYieldToVault("100");
       await underlying.mint(strategy.address, parseUnits("100"));
 
@@ -543,7 +543,7 @@ describe("Vault", () => {
 
     it("returns zero if invested funds is greater or equal than available amount", async () => {
       await vault.connect(owner).setStrategy(strategy.address);
-      await vault.connect(owner).setInvestPerc("9000");
+      await vault.connect(owner).setInvestPct("9000");
       await addYieldToVault("10");
       await underlying.mint(strategy.address, parseUnits("100"));
 


### PR DESCRIPTION
It was driving me crazy that we were using two different abbrevs for "percentage": perc and pct.

So this refactors everything to use "pct"