### PR TITLE
Add main branch instead of master bug

### DIFF
--- a/codechecks.yml
+++ b/codechecks.yml
@@ -1,2 +1,5 @@
 checks:
   - name: eth-gas-reporter/codechecks
+settings:
+  branches:
+    - main


### PR DESCRIPTION
Currently codechecks try to point speculative PRs to `master` branch. Changed this to `main`. This should fix a current bug on main.