### PR TITLE
Add SPONSOR_ROLE to limit access to sponsor

### DIFF
--- a/contracts/Vault.sol
+++ b/contracts/Vault.sol
@@ -388,7 +388,6 @@ contract Vault is
     function unsponsor(address _to, uint256[] calldata _ids)
         external
         nonReentrant
-        onlyRole(SPONSOR_ROLE)
     {
         require(_to != address(0), "Vault: destination address is 0x");
 

--- a/contracts/Vault.sol
+++ b/contracts/Vault.sol
@@ -47,6 +47,9 @@ contract Vault is
     /// Role allowed to change settings such as performance fee and investment fee
     bytes32 public constant SETTINGS_ROLE = keccak256("SETTINGS_ROLE");
 
+    /// Role for sponsors allowed to call sponsor/unsponsor
+    bytes32 public constant SPONSOR_ROLE = keccak256("SPONSOR_ROLE");
+
     /// Minimum lock for each sponsor
     uint64 public constant MIN_SPONSOR_LOCK_DURATION = 2 weeks;
 
@@ -151,6 +154,7 @@ contract Vault is
         _setupRole(DEFAULT_ADMIN_ROLE, _owner);
         _setupRole(INVESTOR_ROLE, _owner);
         _setupRole(SETTINGS_ROLE, _owner);
+        _setupRole(SPONSOR_ROLE, _owner);
 
         investPct = _investPct;
         underlying = _underlying;
@@ -359,7 +363,7 @@ contract Vault is
         address _inputToken,
         uint256 _amount,
         uint256 _lockDuration
-    ) external override(IVaultSponsoring) nonReentrant {
+    ) external override(IVaultSponsoring) nonReentrant onlyRole(SPONSOR_ROLE) {
         require(_amount != 0, "Vault: cannot sponsor 0");
 
         require(
@@ -384,6 +388,7 @@ contract Vault is
     function unsponsor(address _to, uint256[] calldata _ids)
         external
         nonReentrant
+        onlyRole(SPONSOR_ROLE)
     {
         require(_to != address(0), "Vault: destination address is 0x");
 

--- a/test/Vault.spec.ts
+++ b/test/Vault.spec.ts
@@ -60,6 +60,7 @@ describe("Vault", () => {
   const DEFAULT_ADMIN_ROLE = constants.HashZero;
   const INVESTOR_ROLE = utils.keccak256(utils.toUtf8Bytes("INVESTOR_ROLE"));
   const SETTINGS_ROLE = utils.keccak256(utils.toUtf8Bytes("SETTINGS_ROLE"));
+  const SPONSOR_ROLE = utils.keccak256(utils.toUtf8Bytes("SPONSOR_ROLE"));
 
   const fixtures = deployments.createFixture(async ({ deployments }) => {
     await deployments.fixture(["vaults"]);
@@ -306,6 +307,9 @@ describe("Vault", () => {
         await vault.hasRole(DEFAULT_ADMIN_ROLE, owner.address)
       ).to.be.equal(true);
       expect(await vault.hasRole(INVESTOR_ROLE, owner.address)).to.be.equal(
+        true
+      );
+      expect(await vault.hasRole(SPONSOR_ROLE, owner.address)).to.be.equal(
         true
       );
 
@@ -647,24 +651,30 @@ describe("Vault", () => {
   });
 
   describe("sponsor", () => {
+    it("reverts if msg.sender is not sponsor", async () => {
+      await expect(vault.connect(alice).sponsor(underlying.address, parseUnits("500"), TWO_WEEKS))
+         .to.be.revertedWith(getRoleErrorMsg(alice, SPONSOR_ROLE)
+      );
+    });
+
     it("adds a sponsor to the vault", async () => {
-      await addUnderlyingBalance(alice, "1000");
+      await addUnderlyingBalance(owner, "1000");
 
       await vault
-        .connect(alice)
+        .connect(owner)
         .sponsor(underlying.address, parseUnits("500"), TWO_WEEKS);
       await vault
-        .connect(alice)
+        .connect(owner)
         .sponsor(underlying.address, parseUnits("500"), TWO_WEEKS);
 
       expect(await vault.totalSponsored()).to.eq(parseUnits("1000"));
     });
 
     it("emits an event", async () => {
-      await addUnderlyingBalance(alice, "1000");
+      await addUnderlyingBalance(owner, "1000");
 
       const tx = await vault
-        .connect(alice)
+        .connect(owner)
         .sponsor(underlying.address, parseUnits("500"), TWO_WEEKS);
 
       await expect(tx)
@@ -672,67 +682,67 @@ describe("Vault", () => {
         .withArgs(
           1,
           parseUnits("500"),
-          alice.address,
+          owner.address,
           TWO_WEEKS.add(await getLastBlockTimestamp())
         );
     });
 
     it("fails if the lock duration 0", async () => {
-      await addUnderlyingBalance(alice, "1000");
+      await addUnderlyingBalance(owner, "1000");
 
       await expect(
-        vault.connect(alice).sponsor(underlying.address, parseUnits("500"), 0)
+        vault.connect(owner).sponsor(underlying.address, parseUnits("500"), 0)
       ).to.be.revertedWith("Vault: invalid lock period");
     });
 
     it("fails if the lock duration is less than the minimum", async () => {
-      await addUnderlyingBalance(alice, "1000");
+      await addUnderlyingBalance(owner, "1000");
       const lockDuration = 1;
 
       await expect(
         vault
-          .connect(alice)
+          .connect(owner)
           .sponsor(underlying.address, parseUnits("500"), lockDuration)
       ).to.be.revertedWith("Vault: invalid lock period");
     });
 
     it("fails if the lock duration is larger than the maximum", async () => {
-      await addUnderlyingBalance(alice, "1000");
+      await addUnderlyingBalance(owner, "1000");
       const lockDuration = BigNumber.from(time.duration.years(100).toNumber());
 
       await expect(
         vault
-          .connect(alice)
+          .connect(owner)
           .sponsor(underlying.address, parseUnits("500"), lockDuration)
       ).to.be.revertedWith("Vault: invalid lock period");
     });
 
     it("fails if the sponsor amount is 0", async () => {
-      await addUnderlyingBalance(alice, "1000");
+      await addUnderlyingBalance(owner, "1000");
       const lockDuration = BigNumber.from(time.duration.days(15).toNumber());
 
       await expect(
         vault
-          .connect(alice)
+          .connect(owner)
           .sponsor(underlying.address, parseUnits("0"), lockDuration)
       ).to.be.revertedWith("Vault: cannot sponsor 0");
     });
 
     it("mints Depositor NFT to sponsor", async () => {
-      await addUnderlyingBalance(alice, "1000");
+      await addUnderlyingBalance(owner, "1000");
 
       await vault
-        .connect(alice)
+        .connect(owner)
         .sponsor(underlying.address, parseUnits("500"), TWO_WEEKS);
 
-      expect(await depositors.ownerOf("1")).to.be.equal(alice.address);
+      expect(await depositors.ownerOf("1")).to.be.equal(owner.address);
     });
 
     it("updates deposit info for sponsor", async () => {
-      await addUnderlyingBalance(alice, "1000");
+      await addUnderlyingBalance(owner, "1000");
 
       await vault
-        .connect(alice)
+        .connect(owner)
         .sponsor(underlying.address, parseUnits("500"), TWO_WEEKS);
 
       const currentTime = await getLastBlockTimestamp();
@@ -746,30 +756,36 @@ describe("Vault", () => {
 
     it("transfers underlying from user at sponsor", async () => {
       await vault
-        .connect(alice)
+        .connect(owner)
         .sponsor(underlying.address, parseUnits("400"), TWO_WEEKS);
 
       expect(await vault.totalUnderlying()).to.equal(parseUnits("400"));
       expect(await underlying.balanceOf(vault.address)).to.equal(
         parseUnits("400")
       );
-      expect(await underlying.balanceOf(alice.address)).to.equal(
+      expect(await underlying.balanceOf(owner.address)).to.equal(
         parseUnits("600")
       );
     });
   });
 
   describe("unsponsor", () => {
+    it("reverts if msg.sender is not sponsor", async () => {
+      await expect(vault.connect(alice).unsponsor(newAccount.address, [1]))
+         .to.be.revertedWith(getRoleErrorMsg(alice, SPONSOR_ROLE)
+      );
+    });
+
     it("removes a sponsor from the vault", async () => {
       await vault
-        .connect(alice)
+        .connect(owner)
         .sponsor(underlying.address, parseUnits("500"), TWO_WEEKS);
       await vault
-        .connect(alice)
+        .connect(owner)
         .sponsor(underlying.address, parseUnits("500"), TWO_WEEKS);
 
       await moveForwardTwoWeeks();
-      await vault.connect(alice).unsponsor(newAccount.address, [1]);
+      await vault.connect(owner).unsponsor(newAccount.address, [1]);
 
       expect(await vault.totalSponsored()).to.eq(parseUnits("500"));
       expect(await underlying.balanceOf(newAccount.address)).to.eq(
@@ -779,77 +795,80 @@ describe("Vault", () => {
 
     it("emits an event", async () => {
       await vault
-        .connect(alice)
+        .connect(owner)
         .sponsor(underlying.address, parseUnits("500"), TWO_WEEKS);
 
       await moveForwardTwoWeeks();
-      const tx = await vault.connect(alice).unsponsor(bob.address, [1]);
+      const tx = await vault.connect(owner).unsponsor(bob.address, [1]);
 
       await expect(tx).to.emit(vault, "Unsponsored").withArgs(1);
     });
 
     it("fails if the caller is not the owner", async () => {
       await vault
-        .connect(alice)
+        .connect(owner)
         .sponsor(underlying.address, parseUnits("500"), TWO_WEEKS);
 
+      await vault.connect(owner).grantRole(SPONSOR_ROLE, bob.address);
       await expect(
-        vault.connect(bob).unsponsor(alice.address, [1])
+        vault.connect(bob).unsponsor(owner.address, [1])
       ).to.be.revertedWith("Vault: you are not allowed");
+
+      await vault.connect(owner).revokeRole(SPONSOR_ROLE, bob.address);
     });
 
     it("fails if the destination address is 0x", async () => {
       await vault
-        .connect(alice)
+        .connect(owner)
         .sponsor(underlying.address, parseUnits("500"), TWO_WEEKS);
 
       await expect(
         vault
-          .connect(bob)
+          .connect(owner)
           .unsponsor("0x0000000000000000000000000000000000000000", [1])
       ).to.be.revertedWith("Vault: destination address is 0x");
     });
 
     it("fails if the amount is still locked", async () => {
       await vault
-        .connect(alice)
+        .connect(owner)
         .sponsor(underlying.address, parseUnits("500"), TWO_WEEKS);
 
       await expect(
-        vault.connect(alice).unsponsor(alice.address, [1])
+        vault.connect(owner).unsponsor(owner.address, [1])
       ).to.be.revertedWith("Vault: amount is locked");
     });
 
     it("fails if token id belongs to a withdraw", async () => {
-      await vault.connect(alice).deposit(
+      await vault.connect(owner).deposit(
         depositParams.build({
           lockDuration: TWO_WEEKS,
           amount: parseUnits("500"),
           inputToken: underlying.address,
-          claims: [claimParams.percent(100).to(alice.address).build()],
+          claims: [claimParams.percent(100).to(owner.address).build()],
         })
       );
       await vault
-        .connect(alice)
+        .connect(owner)
         .sponsor(underlying.address, parseUnits("500"), TWO_WEEKS);
 
       await moveForwardTwoWeeks();
 
       await expect(
-        vault.connect(alice).unsponsor(alice.address, [1, 2])
+        vault.connect(owner).unsponsor(owner.address, [1, 2])
       ).to.be.revertedWith("Vault: token id is not a sponsor");
     });
 
     it("fails if there are not enough funds", async () => {
       await vault
-        .connect(alice)
+        .connect(owner)
         .sponsor(underlying.address, parseUnits("1000"), TWO_WEEKS);
       await moveForwardTwoWeeks();
 
       await removeUnderlyingFromVault("500");
 
       await expect(
-        vault.connect(alice).unsponsor(alice.address, [1])
+        vault.connect(owner).unsponsor(owner.address, [1])
       ).to.be.revertedWith("Vault: not enough funds");
     });
   });
@@ -1201,22 +1220,22 @@ describe("Vault", () => {
       });
 
       it("fails if token id belongs to a sponsor", async () => {
-        await vault.connect(alice).deposit(
+        await vault.connect(owner).deposit(
           depositParams.build({
             lockDuration: TWO_WEEKS,
             amount: parseUnits("500"),
             inputToken: underlying.address,
-            claims: [claimParams.percent(100).to(alice.address).build()],
+            claims: [claimParams.percent(100).to(owner.address).build()],
           })
         );
         await vault
-          .connect(alice)
+          .connect(owner)
           .sponsor(underlying.address, parseUnits("500"), TWO_WEEKS);
 
         await moveForwardTwoWeeks();
 
         await expect(
-          vault.connect(alice)[vaultAction](alice.address, [1, 2])
+          vault.connect(owner)[vaultAction](owner.address, [1, 2])
         ).to.be.revertedWith("Vault: token id is not a deposit");
       });
     });

--- a/test/Vault.spec.ts
+++ b/test/Vault.spec.ts
@@ -670,6 +670,21 @@ describe("Vault", () => {
       expect(await vault.totalSponsored()).to.eq(parseUnits("1000"));
     });
 
+    it("adds a sponsor to the vault after added sponsor role", async () => {
+      await addUnderlyingBalance(bob, "1000");
+
+      await vault.connect(owner).grantRole(SPONSOR_ROLE, bob.address);
+      await vault
+        .connect(bob)
+        .sponsor(underlying.address, parseUnits("500"), TWO_WEEKS);
+      await vault
+        .connect(bob)
+        .sponsor(underlying.address, parseUnits("500"), TWO_WEEKS);
+      expect(await vault.totalSponsored()).to.eq(parseUnits("1000"));
+
+      await vault.connect(owner).revokeRole(SPONSOR_ROLE, bob.address);
+    });
+
     it("emits an event", async () => {
       await addUnderlyingBalance(owner, "1000");
 
@@ -770,12 +785,6 @@ describe("Vault", () => {
   });
 
   describe("unsponsor", () => {
-    it("reverts if msg.sender is not sponsor", async () => {
-      await expect(vault.connect(alice).unsponsor(newAccount.address, [1]))
-         .to.be.revertedWith(getRoleErrorMsg(alice, SPONSOR_ROLE)
-      );
-    });
-
     it("removes a sponsor from the vault", async () => {
       await vault
         .connect(owner)


### PR DESCRIPTION
Sponsoring is used to boost yield generation for everyone on the Vault, but the side-effect is that it also boosts the loss if the strategy underperforms. We need to make sure the sponsors are parties that will wait for the strategy to normalize if something goes wrong, instead of just withdrawing their money.

- [x] Add role
- [x] Limit access to sponsor/unsponsor
- [x] Update unit tests