### PR TITLE
Add pausability to deposit/sponsor

### DIFF
--- a/contracts/Vault.sol
+++ b/contracts/Vault.sol
@@ -7,6 +7,7 @@ import {Context} from "@openzeppelin/contracts/utils/Context.sol";
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 import {AccessControl} from "@openzeppelin/contracts/access/AccessControl.sol";
 import {ReentrancyGuard} from "@openzeppelin/contracts/security/ReentrancyGuard.sol";
+import {Pausable} from "@openzeppelin/contracts/security/Pausable.sol";
 
 import {IVault} from "./vault/IVault.sol";
 import {IVaultSponsoring} from "./vault/IVaultSponsoring.sol";
@@ -31,7 +32,8 @@ contract Vault is
     Context,
     ERC165,
     AccessControl,
-    ReentrancyGuard
+    ReentrancyGuard,
+    Pausable
 {
     using SafeERC20 for IERC20;
     using PercentMath for uint256;
@@ -229,6 +231,7 @@ contract Vault is
     function deposit(DepositParams calldata _params)
         external
         nonReentrant
+        whenNotPaused
         returns (uint256[] memory depositIds)
     {
         require(_params.amount != 0, "Vault: cannot deposit 0");
@@ -363,7 +366,7 @@ contract Vault is
         address _inputToken,
         uint256 _amount,
         uint256 _lockDuration
-    ) external override(IVaultSponsoring) nonReentrant onlyRole(SPONSOR_ROLE) {
+    ) external override(IVaultSponsoring) nonReentrant onlyRole(SPONSOR_ROLE) whenNotPaused {
         require(_amount != 0, "Vault: cannot sponsor 0");
 
         require(
@@ -937,5 +940,13 @@ contract Vault is
 
     function principalOf(uint256 claimerId) external view returns (uint256) {
         return claimer[claimerId].totalPrincipal;
+    }
+
+    function pause() external onlyRole(DEFAULT_ADMIN_ROLE) {
+        _pause();
+    }
+
+    function unpause() external onlyRole(DEFAULT_ADMIN_ROLE) {
+        _unpause();
     }
 }


### PR DESCRIPTION
If for some reason our users have to move to a new Vault, we need a mechanism in place to ensure that we can “disable” the Vault and tell people that a new one is available.

- [x] Add Pausability for deposit/sponsor
- [x] Add unit tests