### PR TITLE
Add pausability to deposit/sponsor

### DIFF
--- a/contracts/Vault.sol
+++ b/contracts/Vault.sol
@@ -362,7 +362,7 @@ contract Vault is
         address _inputToken,
         uint256 _amount,
         uint256 _lockDuration
-    ) external override(IVaultSponsoring) nonReentrant onlyRole(SPONSOR_ROLE) whenNotPaused {
+    ) external override(IVaultSponsoring) nonReentrant whenNotPaused {
         require(_amount != 0, "Vault: cannot sponsor 0");
 
         require(

--- a/test/Vault.spec.ts
+++ b/test/Vault.spec.ts
@@ -647,6 +647,21 @@ describe("Vault", () => {
   });
 
   describe("sponsor", () => {
+
+    it("reverts if msg.sender is not sponsor", async () => {
+      await expect(vault.connect(alice).sponsor(underlying.address, parseUnits("500"), TWO_WEEKS))
+         .to.be.revertedWith(getRoleErrorMsg(alice, SPONSOR_ROLE)
+      );
+    });
+
+    it("reverts if contract is paused", async () => {
+      await vault.connect(owner).pause();
+      await expect(vault.connect(owner).sponsor(underlying.address, parseUnits("500"), TWO_WEEKS))
+         .to.be.revertedWith("Pausable: paused"
+      );
+      await vault.connect(owner).unpause();
+    });
+
     it("adds a sponsor to the vault", async () => {
       await addUnderlyingBalance(alice, "1000");
 
@@ -855,6 +870,24 @@ describe("Vault", () => {
   });
 
   describe("deposit", () => {
+    it("reverts if contract is paused", async () => {
+      const params = depositParams.build({
+        lockDuration: TWO_WEEKS,
+        amount: parseUnits("100"),
+        inputToken: underlying.address,
+        claims: [
+          claimParams.percent(50).to(carol.address).build(),
+          claimParams.percent(50).to(bob.address).build(),
+        ],
+        name: "Deposit - Emits Different groupId",
+      });
+      await vault.connect(owner).pause();
+      await expect(vault.connect(owner).deposit(params))
+         .to.be.revertedWith("Pausable: paused"
+      );
+      await vault.connect(owner).unpause();
+    });
+
     it("emits events", async () => {
       const params = depositParams.build({
         lockDuration: TWO_WEEKS,
@@ -1738,6 +1771,17 @@ describe("Vault", () => {
       expect(await depositors.ownerOf("1")).to.be.equal(alice.address);
       expect(await claimers.ownerOf("1")).to.be.equal(bob.address);
       expect(await claimers.ownerOf("2")).to.be.equal(carol.address);
+    });
+  });
+
+  describe("pause/unpause", () => {
+    it("reverts(pause) if not DEFAULT_ADMIN_ROLE", async () => {
+      await expect(vault.connect(alice).pause())
+         .to.be.revertedWith(getRoleErrorMsg(alice, DEFAULT_ADMIN_ROLE));
+    });
+    it("reverts(unpause) if not DEFAULT_ADMIN_ROLE", async () => {
+      await expect(vault.connect(alice).unpause())
+         .to.be.revertedWith(getRoleErrorMsg(alice, DEFAULT_ADMIN_ROLE));
     });
   });
 

--- a/test/Vault.spec.ts
+++ b/test/Vault.spec.ts
@@ -647,13 +647,6 @@ describe("Vault", () => {
   });
 
   describe("sponsor", () => {
-
-    it("reverts if msg.sender is not sponsor", async () => {
-      await expect(vault.connect(alice).sponsor(underlying.address, parseUnits("500"), TWO_WEEKS))
-         .to.be.revertedWith(getRoleErrorMsg(alice, SPONSOR_ROLE)
-      );
-    });
-
     it("reverts if contract is paused", async () => {
       await vault.connect(owner).pause();
       await expect(vault.connect(owner).sponsor(underlying.address, parseUnits("500"), TWO_WEEKS))


### PR DESCRIPTION
If for some reason our users have to move to a new Vault, we need a mechanism in place to ensure that we can “disable” the Vault and tell people that a new one is available.

- [x] Add Pausability for deposit/sponsor
- [x] Add unit tests