### PR TITLE
Improve and fix the subgraph

### DIFF
--- a/contracts/Vault.sol
+++ b/contracts/Vault.sol
@@ -163,7 +163,6 @@ contract Vault is
         perfFeePct = _perfFeePct;
         lossTolerancePct = _lossTolerancePct;
 
-
         rebalanceMinimum = 10 * 10**underlying.decimals();
 
         _addPools(_swapPools);
@@ -296,6 +295,9 @@ contract Vault is
 
         if (yield == 0) return;
 
+        uint256 _totalUnderlyingMinusSponsored = totalUnderlyingMinusSponsored();
+        uint256 _totalShares = totalShares;
+
         accumulatedPerfFee += fee;
 
         underlying.safeTransfer(_to, yield);
@@ -303,7 +305,15 @@ contract Vault is
         claimer[msg.sender].totalShares -= shares;
         totalShares -= shares;
 
-        emit YieldClaimed(msg.sender, _to, yield, shares, fee);
+        emit YieldClaimed(
+            msg.sender,
+            _to,
+            yield,
+            shares,
+            fee,
+            _totalUnderlyingMinusSponsored,
+            _totalShares
+        );
     }
 
     /// @inheritdoc IVault

--- a/contracts/vault/IVault.sol
+++ b/contracts/vault/IVault.sol
@@ -74,7 +74,9 @@ interface IVault {
         address indexed to,
         uint256 amount,
         uint256 burnedShares,
-        uint256 perfFee
+        uint256 perfFee,
+        uint256 totalUnderlying,
+        uint256 totalShares
     );
 
     event FeeWithdrawn(uint256 amount);

--- a/subgraph/package.json
+++ b/subgraph/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@graphprotocol/graph-cli": "0.25.1",
     "@graphprotocol/graph-ts": "0.24.1",
-    "matchstick-as": "^0.3.0",
+    "matchstick-as": "^0.4.3",
     "mustache": "^4.2.0"
   },
   "devDependencies": {}

--- a/subgraph/schema.graphql
+++ b/subgraph/schema.graphql
@@ -15,6 +15,7 @@ type Foundation @entity {
   deposits: [Deposit!]! @derivedFrom(field: "foundation")
   amountDeposited: BigInt!
   shares: BigInt!
+  amountClaimed: BigInt!
   lockedUntil: BigInt!
   createdAt: BigInt!
 }

--- a/subgraph/schema.graphql
+++ b/subgraph/schema.graphql
@@ -14,6 +14,7 @@ type Foundation @entity {
   vault: Vault!
   deposits: [Deposit!]! @derivedFrom(field: "foundation")
   amountDeposited: BigInt!
+  shares: BigInt!
   lockedUntil: BigInt!
   createdAt: BigInt!
 }
@@ -31,7 +32,7 @@ type Deposit @entity {
 }
 
 type Claimer @entity {
-  id: Bytes!
+  id: ID!
   owner: Bytes!
   vault: Vault!
   deposits: [Deposit!]! @derivedFrom(field: "claimer")

--- a/subgraph/schema.graphql
+++ b/subgraph/schema.graphql
@@ -31,7 +31,7 @@ type Deposit @entity {
 }
 
 type Claimer @entity {
-  id: ID!
+  id: Bytes!
   owner: Bytes!
   vault: Vault!
   deposits: [Deposit!]! @derivedFrom(field: "claimer")

--- a/subgraph/src/mappings/vault.ts
+++ b/subgraph/src/mappings/vault.ts
@@ -31,7 +31,6 @@ export function handleYieldClaimed(event: YieldClaimed): void {
   let totalClaimedShares = new BigInt(0);
 
   // The price per share s the event's claimed amount divided by the burned shares.
-  const pricePerSare = claimedAmount.div(event.params.burnedShares);
 
   for (let i = 0; i < claimer.depositsIds.length; i++) {
     const deposit = Deposit.load(claimer.depositsIds[i]);
@@ -45,12 +44,13 @@ export function handleYieldClaimed(event: YieldClaimed): void {
     // The deposit's claimed amount it the same as the deposit's yield.
     // Which is the difference between the deposit's amount and what its shares are worth right now.
     const depositClaimedAmount = deposit.shares
-      .times(pricePerSare)
+      .times(event.params.totalUnderlying)
+      .div(event.params.totalShares)
       .minus(deposit.amount);
 
     const depositClaimedShares = depositClaimedAmount
-      .times(event.params.burnedShares)
-      .div(claimedAmount);
+      .times(event.params.totalShares)
+      .div(event.params.totalUnderlying);
 
     totalClaimedShares = totalClaimedShares.plus(depositClaimedShares);
 

--- a/subgraph/src/mappings/vault.ts
+++ b/subgraph/src/mappings/vault.ts
@@ -1,10 +1,4 @@
-import {
-  BigDecimal,
-  BigInt,
-  ByteArray,
-  log,
-  Bytes,
-} from '@graphprotocol/graph-ts';
+import { BigInt, log } from '@graphprotocol/graph-ts';
 import {
   DepositWithdrawn,
   DepositMinted,

--- a/subgraph/src/mappings/vault.ts
+++ b/subgraph/src/mappings/vault.ts
@@ -167,13 +167,20 @@ export function handleDepositWithdrawn(event: DepositWithdrawn): void {
 
   claimer.principal = claimer.principal.minus(deposit.amount);
   claimer.shares = claimer.shares.minus(event.params.shares);
-  claimer.depositsIds = claimer.depositsIds.filter(
-    (id: string) => id !== depositId,
-  );
 
-  deposit.burned = true;
+  if (event.params.burned) {
+    claimer.depositsIds = claimer.depositsIds.filter(
+      (id: string) => id !== depositId,
+    );
+
+    deposit.burned = true;
+  }
+
+  deposit.amount = deposit.amount.minus(event.params.amount);
+  deposit.shares = deposit.shares.minus(event.params.shares);
+
   vault.totalShares = vault.totalShares.minus(event.params.shares);
-  log.debug('burn, subbing shares {}', [event.params.shares.toString()]);
+  log.debug('subbing shares {}', [event.params.shares.toString()]);
 
   foundation.amountDeposited = foundation.amountDeposited.minus(deposit.amount);
 

--- a/subgraph/src/mappings/vault.ts
+++ b/subgraph/src/mappings/vault.ts
@@ -184,9 +184,22 @@ export function handleDepositWithdrawn(event: DepositWithdrawn): void {
   vault.totalShares = vault.totalShares.minus(event.params.shares);
   log.debug('subbing shares {}', [event.params.shares.toString()]);
 
-  foundation.amountDeposited = foundation.amountDeposited.minus(deposit.amount);
+  log.debug('ASJDLSADA {} {}', [
+    foundation.amountDeposited.toString(),
+    foundation.shares.toString(),
+  ]);
+  log.debug('ASJDLSADA {} {}', [
+    event.params.amount.toString(),
+    event.params.shares.toString(),
+  ]);
+
+  foundation.amountDeposited = foundation.amountDeposited.minus(
+    event.params.amount,
+  );
+  foundation.shares = foundation.shares.minus(event.params.shares);
 
   claimer.save();
+  foundation.save();
   deposit.save();
   vault.save();
 }

--- a/subgraph/src/mappings/vault.ts
+++ b/subgraph/src/mappings/vault.ts
@@ -117,10 +117,12 @@ export function handleDepositMinted(event: DepositMinted): void {
     foundation.vault = vaultId;
     foundation.owner = event.params.depositor;
     foundation.createdAt = event.block.timestamp;
-    foundation.lockedUntil = event.params.lockedUntil;
     foundation.amountDeposited = BigInt.fromString('0');
+    foundation.shares = BigInt.fromString('0');
   }
 
+  foundation.lockedUntil = event.params.lockedUntil;
+  foundation.shares = foundation.shares.plus(event.params.shares);
   foundation.name = event.params.name;
   foundation.amountDeposited = foundation.amountDeposited.plus(
     event.params.amount,

--- a/subgraph/src/mappings/vault.ts
+++ b/subgraph/src/mappings/vault.ts
@@ -30,8 +30,6 @@ export function handleYieldClaimed(event: YieldClaimed): void {
   const claimedAmount = event.params.amount.plus(event.params.perfFee);
   let totalClaimedShares = new BigInt(0);
 
-  // The price per share s the event's claimed amount divided by the burned shares.
-
   for (let i = 0; i < claimer.depositsIds.length; i++) {
     const deposit = Deposit.load(claimer.depositsIds[i]);
 

--- a/subgraph/subgraph.template.yaml
+++ b/subgraph/subgraph.template.yaml
@@ -37,7 +37,7 @@ dataSources:
           handler: handleSponsored
         - event: Unsponsored(indexed uint256)
           handler: handleUnsponsored
-        - event: YieldClaimed(address,indexed address,uint256,uint256,uint256)
+        - event: YieldClaimed(address,indexed address,uint256,uint256,uint256,uint256,uint256)
           handler: handleYieldClaimed
         - event: TreasuryUpdated(indexed address)
           handler: handleTreasuryUpdated

--- a/subgraph/tests/helpers.ts
+++ b/subgraph/tests/helpers.ts
@@ -10,6 +10,16 @@ export function newI32(name: string, value: i32): ethereum.EventParam {
   return new ethereum.EventParam(name, ethereum.Value.fromI32(value));
 }
 
+export function newI32FromBigInt(
+  name: string,
+  value: string,
+): ethereum.EventParam {
+  return new ethereum.EventParam(
+    name,
+    ethereum.Value.fromUnsignedBigInt(BigInt.fromString(value)),
+  );
+}
+
 export function newBool(name: string, value: bool): ethereum.EventParam {
   return new ethereum.EventParam(name, ethereum.Value.fromBoolean(value));
 }

--- a/subgraph/tests/helpers.ts
+++ b/subgraph/tests/helpers.ts
@@ -1,0 +1,51 @@
+import { ethereum, Address, Bytes, BigInt } from '@graphprotocol/graph-ts';
+
+import { Deposit } from '../src/types/schema';
+
+export function newBytes(name: string, value: Bytes): ethereum.EventParam {
+  return new ethereum.EventParam(name, ethereum.Value.fromBytes(value));
+}
+
+export function newI32(name: string, value: i32): ethereum.EventParam {
+  return new ethereum.EventParam(name, ethereum.Value.fromI32(value));
+}
+
+export function newBool(name: string, value: bool): ethereum.EventParam {
+  return new ethereum.EventParam(name, ethereum.Value.fromBoolean(value));
+}
+
+export function newAddress(name: string, value: string): ethereum.EventParam {
+  return new ethereum.EventParam(
+    name,
+    ethereum.Value.fromAddress(Address.fromString(value)),
+  );
+}
+
+export function newString(name: string, value: string): ethereum.EventParam {
+  return new ethereum.EventParam(name, ethereum.Value.fromString(value));
+}
+
+export function donationId(event: ethereum.Event, id: string): string {
+  return (
+    event.transaction.hash.toHex() + '-' + event.logIndex.toString() + '-' + id
+  );
+}
+
+export function createDeposit(
+  id: string,
+  amount: i32,
+  burned: bool,
+  claimer: string,
+  foundation: string,
+  lockedUntil: i32,
+  shares: i32,
+): void {
+  const deposit = new Deposit(id);
+  deposit.amount = BigInt.fromI32(amount);
+  deposit.burned = burned;
+  deposit.claimer = claimer;
+  deposit.foundation = foundation;
+  deposit.lockedUntil = BigInt.fromI32(lockedUntil);
+  deposit.shares = BigInt.fromI32(shares);
+  deposit.save();
+}

--- a/subgraph/tests/integration.test.ts
+++ b/subgraph/tests/integration.test.ts
@@ -18,50 +18,23 @@ import {
 
 import {
   handleDepositMinted,
-  handleSponsored,
-  handleUnsponsored,
   handleDepositWithdrawn,
   handleYieldClaimed,
-  handleTreasuryUpdated,
 } from '../src/mappings/vault';
-import {
-  handleInitDeposit,
-  handleInitRedeem,
-  handleFinishDeposit,
-  handleFinishRedeem,
-  handleRearrangeDeposit,
-  handleRearrangeRedeem,
-} from '../src/mappings/strategy';
-import { Sponsored, Unsponsored } from '../src/types/Vault/IVaultSponsoring';
+
 import {
   DepositWithdrawn,
   DepositMinted,
   YieldClaimed,
 } from '../src/types/Vault/IVault';
-import { TreasuryUpdated } from '../src/types/Vault/IVaultSettings';
-import {
-  Vault,
-  Deposit,
-  Sponsor,
-  Claimer,
-  Foundation,
-  DepositOperation,
-  RedeemOperation,
-} from '../src/types/schema';
-import {
-  FinishDepositStable,
-  FinishRedeemStable,
-  InitDepositStable,
-  InitRedeemStable,
-  RearrangeDepositOperation,
-  RearrangeRedeemOperation,
-} from '../src/types/Strategy/AnchorStrategy';
+
+import { Vault, Claimer, Foundation } from '../src/types/schema';
 
 const MOCK_ADDRESS_1 = '0xC80B3caAd6d2DE80Ac76a41d5F0072E36D2519Cd'.toLowerCase();
 const MOCK_ADDRESS_2 = '0xE80B3caAd6d2DE80Ac76a41d5F0072E36D2519Ce'.toLowerCase();
 const TREASURY_ADDRESS = '0x4940c6e628da11ac0bdcf7f82be8579b4696fa33';
 
-test('handleDepositMinted updates the Foundation', () => {
+test('updates the Foundation', () => {
   clearStore();
 
   let mockEvent = newMockEvent();
@@ -131,7 +104,7 @@ test('handleDepositMinted updates the Foundation', () => {
   );
   event2.parameters = new Array();
 
-  idParam = newI32('id', 1);
+  idParam = newI32('id', 2);
   amount = newI32('amount', 20);
   shares = newI32('shares', 15);
   depositor = newAddress('depositor', MOCK_ADDRESS_1);
@@ -165,6 +138,31 @@ test('handleDepositMinted updates the Foundation', () => {
     'createdAt',
     event.block.timestamp.toString(),
   );
+
+  // Partial withdraw
+
+  mockEvent = newMockEvent();
+  const event3 = new DepositWithdrawn(
+    mockEvent.address,
+    mockEvent.logIndex,
+    mockEvent.transactionLogIndex,
+    mockEvent.logType,
+    mockEvent.block,
+    mockEvent.transaction,
+    mockEvent.parameters,
+  );
+  event3.parameters = new Array();
+
+  event3.parameters.push(newI32('id', 1));
+  event3.parameters.push(newI32('shares', 5));
+  event3.parameters.push(newI32('amount', 10));
+  event3.parameters.push(newAddress('to', MOCK_ADDRESS_1));
+  event3.parameters.push(newBool('burned', false));
+
+  handleDepositWithdrawn(event3);
+
+  assert.fieldEquals('Foundation', foundationId, 'amountDeposited', '20');
+  assert.fieldEquals('Foundation', foundationId, 'shares', '20');
 });
 
 test('handleYieldClaimed handles scenarios where only one of the deposits generated yield', () => {

--- a/subgraph/tests/integration.test.ts
+++ b/subgraph/tests/integration.test.ts
@@ -1,10 +1,11 @@
-import { log, ethereum, Address, Bytes, BigInt } from "@graphprotocol/graph-ts";
+import { ethereum, Address, Bytes, BigInt } from '@graphprotocol/graph-ts';
+import { log } from 'matchstick-as/assembly/log';
 import {
   test,
   assert,
   newMockEvent,
-  clearStore
-} from "matchstick-as/assembly/index";
+  clearStore,
+} from 'matchstick-as/assembly/index';
 
 import {
   handleDepositMinted,
@@ -12,23 +13,23 @@ import {
   handleUnsponsored,
   handleDepositWithdrawn,
   handleYieldClaimed,
-  handleTreasuryUpdated
-} from "../src/mappings/vault";
+  handleTreasuryUpdated,
+} from '../src/mappings/vault';
 import {
   handleInitDeposit,
   handleInitRedeem,
   handleFinishDeposit,
   handleFinishRedeem,
   handleRearrangeDeposit,
-  handleRearrangeRedeem
-} from "../src/mappings/strategy";
-import { Sponsored, Unsponsored } from "../src/types/Vault/IVaultSponsoring";
+  handleRearrangeRedeem,
+} from '../src/mappings/strategy';
+import { Sponsored, Unsponsored } from '../src/types/Vault/IVaultSponsoring';
 import {
   DepositWithdrawn,
   DepositMinted,
-  YieldClaimed
-} from "../src/types/Vault/IVault";
-import { TreasuryUpdated } from "../src/types/Vault/IVaultSettings";
+  YieldClaimed,
+} from '../src/types/Vault/IVault';
+import { TreasuryUpdated } from '../src/types/Vault/IVaultSettings';
 import {
   Vault,
   Deposit,
@@ -36,22 +37,22 @@ import {
   Claimer,
   Foundation,
   DepositOperation,
-  RedeemOperation
-} from "../src/types/schema";
+  RedeemOperation,
+} from '../src/types/schema';
 import {
   FinishDepositStable,
   FinishRedeemStable,
   InitDepositStable,
   InitRedeemStable,
   RearrangeDepositOperation,
-  RearrangeRedeemOperation
-} from "../src/types/Strategy/AnchorStrategy";
+  RearrangeRedeemOperation,
+} from '../src/types/Strategy/AnchorStrategy';
 
-const MOCK_ADDRESS_1 = "0xC80B3caAd6d2DE80Ac76a41d5F0072E36D2519Cd".toLowerCase();
-const MOCK_ADDRESS_2 = "0xE80B3caAd6d2DE80Ac76a41d5F0072E36D2519Ce".toLowerCase();
-const TREASURY_ADDRESS = "0x4940c6e628da11ac0bdcf7f82be8579b4696fa33";
+const MOCK_ADDRESS_1 = '0xC80B3caAd6d2DE80Ac76a41d5F0072E36D2519Cd'.toLowerCase();
+const MOCK_ADDRESS_2 = '0xE80B3caAd6d2DE80Ac76a41d5F0072E36D2519Ce'.toLowerCase();
+const TREASURY_ADDRESS = '0x4940c6e628da11ac0bdcf7f82be8579b4696fa33';
 
-test("handleInitDeposit creates a DepositOperation", () => {
+test('handleInitDeposit creates a DepositOperation', () => {
   clearStore();
 
   let mockEvent = newMockEvent();
@@ -62,14 +63,14 @@ test("handleInitDeposit creates a DepositOperation", () => {
     mockEvent.logType,
     mockEvent.block,
     mockEvent.transaction,
-    mockEvent.parameters
+    mockEvent.parameters,
   );
   event.parameters = new Array();
 
-  const operator = newAddress("operator", MOCK_ADDRESS_1);
-  const idx = newI32("idx", 1);
-  const underlyingAmount = newI32("underlyingAmount", 1);
-  const ustAmount = newI32("ustAmount", 1);
+  const operator = newAddress('operator', MOCK_ADDRESS_1);
+  const idx = newI32('idx', 1);
+  const underlyingAmount = newI32('underlyingAmount', 1);
+  const ustAmount = newI32('ustAmount', 1);
 
   event.parameters.push(operator);
   event.parameters.push(idx);
@@ -78,17 +79,17 @@ test("handleInitDeposit creates a DepositOperation", () => {
 
   handleInitDeposit(event);
 
-  assert.fieldEquals("DepositOperation", MOCK_ADDRESS_1, "idx", "1");
+  assert.fieldEquals('DepositOperation', MOCK_ADDRESS_1, 'idx', '1');
   assert.fieldEquals(
-    "DepositOperation",
+    'DepositOperation',
     MOCK_ADDRESS_1,
-    "underlyingAmount",
-    "1"
+    'underlyingAmount',
+    '1',
   );
-  assert.fieldEquals("DepositOperation", MOCK_ADDRESS_1, "ustAmount", "1");
+  assert.fieldEquals('DepositOperation', MOCK_ADDRESS_1, 'ustAmount', '1');
 });
 
-test("RearrangeDepositOperation updates the DepositOperation idx", () => {
+test('RearrangeDepositOperation updates the DepositOperation idx', () => {
   clearStore();
 
   let mockDepositEvent = newMockEvent();
@@ -99,14 +100,14 @@ test("RearrangeDepositOperation updates the DepositOperation idx", () => {
     mockDepositEvent.logType,
     mockDepositEvent.block,
     mockDepositEvent.transaction,
-    mockDepositEvent.parameters
+    mockDepositEvent.parameters,
   );
   depositEvent.parameters = new Array();
 
-  let operator = newAddress("operator", MOCK_ADDRESS_1);
-  let idx = newI32("idx", 1);
-  let underlyingAmount = newI32("underlyingAmount", 1);
-  let ustAmount = newI32("ustAmount", 1);
+  let operator = newAddress('operator', MOCK_ADDRESS_1);
+  let idx = newI32('idx', 1);
+  let underlyingAmount = newI32('underlyingAmount', 1);
+  let ustAmount = newI32('ustAmount', 1);
 
   depositEvent.parameters.push(operator);
   depositEvent.parameters.push(idx);
@@ -123,12 +124,12 @@ test("RearrangeDepositOperation updates the DepositOperation idx", () => {
     mockDepositEvent1.logType,
     mockDepositEvent1.block,
     mockDepositEvent1.transaction,
-    mockDepositEvent1.parameters
+    mockDepositEvent1.parameters,
   );
   depositEvent1.parameters = new Array();
 
-  operator = newAddress("operator", MOCK_ADDRESS_2);
-  idx = newI32("idx", 2);
+  operator = newAddress('operator', MOCK_ADDRESS_2);
+  idx = newI32('idx', 2);
 
   depositEvent1.parameters.push(operator);
   depositEvent1.parameters.push(idx);
@@ -145,28 +146,28 @@ test("RearrangeDepositOperation updates the DepositOperation idx", () => {
     mockEvent.logType,
     mockEvent.block,
     mockEvent.transaction,
-    mockEvent.parameters
+    mockEvent.parameters,
   );
   event.parameters = new Array();
 
-  const operatorFrom = newAddress("operatorFrom", MOCK_ADDRESS_2);
-  const operatorTo = newAddress("operatorTo", MOCK_ADDRESS_1);
-  idx = newI32("idx", 1);
+  const operatorFrom = newAddress('operatorFrom', MOCK_ADDRESS_2);
+  const operatorTo = newAddress('operatorTo', MOCK_ADDRESS_1);
+  idx = newI32('idx', 1);
 
   event.parameters.push(operatorFrom);
   event.parameters.push(operatorTo);
   event.parameters.push(idx);
 
-  assert.fieldEquals("DepositOperation", MOCK_ADDRESS_2, "idx", "2");
-  assert.fieldEquals("DepositOperation", MOCK_ADDRESS_1, "idx", "1");
+  assert.fieldEquals('DepositOperation', MOCK_ADDRESS_2, 'idx', '2');
+  assert.fieldEquals('DepositOperation', MOCK_ADDRESS_1, 'idx', '1');
 
   handleRearrangeDeposit(event);
 
-  assert.fieldEquals("DepositOperation", MOCK_ADDRESS_2, "idx", "1");
-  assert.fieldEquals("DepositOperation", MOCK_ADDRESS_1, "idx", "1");
+  assert.fieldEquals('DepositOperation', MOCK_ADDRESS_2, 'idx', '1');
+  assert.fieldEquals('DepositOperation', MOCK_ADDRESS_1, 'idx', '1');
 });
 
-test("handleFinishDeposit deletes the DepositOperation", () => {
+test('handleFinishDeposit deletes the DepositOperation', () => {
   clearStore();
 
   const depositOperation = new DepositOperation(MOCK_ADDRESS_1);
@@ -180,20 +181,20 @@ test("handleFinishDeposit deletes the DepositOperation", () => {
     mockEvent.logType,
     mockEvent.block,
     mockEvent.transaction,
-    mockEvent.parameters
+    mockEvent.parameters,
   );
   event.parameters = new Array();
 
-  const operator = newAddress("operator", MOCK_ADDRESS_1);
+  const operator = newAddress('operator', MOCK_ADDRESS_1);
 
   event.parameters.push(operator);
 
   handleFinishDeposit(event);
 
-  assert.notInStore("DepositOperation", MOCK_ADDRESS_1);
+  assert.notInStore('DepositOperation', MOCK_ADDRESS_1);
 });
 
-test("handleInitRedeem creates a RedeemOperation", () => {
+test('handleInitRedeem creates a RedeemOperation', () => {
   clearStore();
 
   let mockEvent = newMockEvent();
@@ -204,13 +205,13 @@ test("handleInitRedeem creates a RedeemOperation", () => {
     mockEvent.logType,
     mockEvent.block,
     mockEvent.transaction,
-    mockEvent.parameters
+    mockEvent.parameters,
   );
   event.parameters = new Array();
 
-  const operator = newAddress("operator", MOCK_ADDRESS_1);
-  const idx = newI32("idx", 1);
-  const aUstAmount = newI32("aUstAmount", 1);
+  const operator = newAddress('operator', MOCK_ADDRESS_1);
+  const idx = newI32('idx', 1);
+  const aUstAmount = newI32('aUstAmount', 1);
 
   event.parameters.push(operator);
   event.parameters.push(idx);
@@ -218,10 +219,10 @@ test("handleInitRedeem creates a RedeemOperation", () => {
 
   handleInitRedeem(event);
 
-  assert.fieldEquals("RedeemOperation", MOCK_ADDRESS_1, "aUstAmount", "1");
+  assert.fieldEquals('RedeemOperation', MOCK_ADDRESS_1, 'aUstAmount', '1');
 });
 
-test("RearrangeRedeemOperation updates the RedeemOperation idx", () => {
+test('RearrangeRedeemOperation updates the RedeemOperation idx', () => {
   clearStore();
 
   let mockRedeemEvent = newMockEvent();
@@ -232,13 +233,13 @@ test("RearrangeRedeemOperation updates the RedeemOperation idx", () => {
     mockRedeemEvent.logType,
     mockRedeemEvent.block,
     mockRedeemEvent.transaction,
-    mockRedeemEvent.parameters
+    mockRedeemEvent.parameters,
   );
   redeemEvent.parameters = new Array();
 
-  let operator = newAddress("operator", MOCK_ADDRESS_1);
-  let aUstAmount = newI32("aUstAmount", 1);
-  let idx = newI32("idx", 1);
+  let operator = newAddress('operator', MOCK_ADDRESS_1);
+  let aUstAmount = newI32('aUstAmount', 1);
+  let idx = newI32('idx', 1);
 
   redeemEvent.parameters.push(operator);
   redeemEvent.parameters.push(idx);
@@ -254,12 +255,12 @@ test("RearrangeRedeemOperation updates the RedeemOperation idx", () => {
     mockRedeemEvent1.logType,
     mockRedeemEvent1.block,
     mockRedeemEvent1.transaction,
-    mockRedeemEvent1.parameters
+    mockRedeemEvent1.parameters,
   );
   redeemEvent1.parameters = new Array();
 
-  operator = newAddress("operator", MOCK_ADDRESS_2);
-  idx = newI32("idx", 2);
+  operator = newAddress('operator', MOCK_ADDRESS_2);
+  idx = newI32('idx', 2);
 
   redeemEvent1.parameters.push(operator);
   redeemEvent1.parameters.push(idx);
@@ -275,28 +276,28 @@ test("RearrangeRedeemOperation updates the RedeemOperation idx", () => {
     mockEvent.logType,
     mockEvent.block,
     mockEvent.transaction,
-    mockEvent.parameters
+    mockEvent.parameters,
   );
   event.parameters = new Array();
 
-  const operatorFrom = newAddress("operatorFrom", MOCK_ADDRESS_2);
-  const operatorTo = newAddress("operatorTo", MOCK_ADDRESS_1);
-  idx = newI32("idx", 1);
+  const operatorFrom = newAddress('operatorFrom', MOCK_ADDRESS_2);
+  const operatorTo = newAddress('operatorTo', MOCK_ADDRESS_1);
+  idx = newI32('idx', 1);
 
   event.parameters.push(operatorFrom);
   event.parameters.push(operatorTo);
   event.parameters.push(idx);
 
-  assert.fieldEquals("RedeemOperation", MOCK_ADDRESS_2, "idx", "2");
-  assert.fieldEquals("RedeemOperation", MOCK_ADDRESS_1, "idx", "1");
+  assert.fieldEquals('RedeemOperation', MOCK_ADDRESS_2, 'idx', '2');
+  assert.fieldEquals('RedeemOperation', MOCK_ADDRESS_1, 'idx', '1');
 
   handleRearrangeRedeem(event);
 
-  assert.fieldEquals("RedeemOperation", MOCK_ADDRESS_2, "idx", "1");
-  assert.fieldEquals("RedeemOperation", MOCK_ADDRESS_1, "idx", "1");
+  assert.fieldEquals('RedeemOperation', MOCK_ADDRESS_2, 'idx', '1');
+  assert.fieldEquals('RedeemOperation', MOCK_ADDRESS_1, 'idx', '1');
 });
 
-test("handleFinishRedeem updates the RedeemOperation", () => {
+test('handleFinishRedeem updates the RedeemOperation', () => {
   clearStore();
 
   const depositOperation = new RedeemOperation(MOCK_ADDRESS_1);
@@ -310,20 +311,20 @@ test("handleFinishRedeem updates the RedeemOperation", () => {
     mockEvent.logType,
     mockEvent.block,
     mockEvent.transaction,
-    mockEvent.parameters
+    mockEvent.parameters,
   );
   event.parameters = new Array();
 
-  const operator = newAddress("operator", MOCK_ADDRESS_1);
+  const operator = newAddress('operator', MOCK_ADDRESS_1);
 
   event.parameters.push(operator);
 
   handleFinishRedeem(event);
 
-  assert.notInStore("RedeemOperation", MOCK_ADDRESS_1);
+  assert.notInStore('RedeemOperation', MOCK_ADDRESS_1);
 });
 
-test("handleTreasuryUpdated updates the treasury", () => {
+test('handleTreasuryUpdated updates the treasury', () => {
   clearStore();
 
   let mockEvent = newMockEvent();
@@ -334,11 +335,11 @@ test("handleTreasuryUpdated updates the treasury", () => {
     mockEvent.logType,
     mockEvent.block,
     mockEvent.transaction,
-    mockEvent.parameters
+    mockEvent.parameters,
   );
   event.parameters = new Array();
 
-  const treasury = newAddress("treasury", MOCK_ADDRESS_1);
+  const treasury = newAddress('treasury', MOCK_ADDRESS_1);
   event.parameters.push(treasury);
 
   // create vault
@@ -348,14 +349,14 @@ test("handleTreasuryUpdated updates the treasury", () => {
   handleTreasuryUpdated(event);
 
   assert.fieldEquals(
-    "Vault",
+    'Vault',
     mockEvent.address.toHexString(),
-    "treasury",
-    MOCK_ADDRESS_1
+    'treasury',
+    MOCK_ADDRESS_1,
   );
 });
 
-test("handleSponsored creates a Sponsor", () => {
+test('handleSponsored creates a Sponsor', () => {
   clearStore();
 
   let mockEvent = newMockEvent();
@@ -366,15 +367,15 @@ test("handleSponsored creates a Sponsor", () => {
     mockEvent.logType,
     mockEvent.block,
     mockEvent.transaction,
-    mockEvent.parameters
+    mockEvent.parameters,
   );
   event.parameters = new Array();
 
-  const idParam = newI32("id", 1);
-  const amount = newI32("amount", 1);
-  const depositor = newAddress("depositor", MOCK_ADDRESS_1);
-  const lockedUntil = newI32("lockedUntil", 1);
-  const burned = newBool("burned", false);
+  const idParam = newI32('id', 1);
+  const amount = newI32('amount', 1);
+  const depositor = newAddress('depositor', MOCK_ADDRESS_1);
+  const lockedUntil = newI32('lockedUntil', 1);
+  const burned = newBool('burned', false);
 
   event.parameters.push(idParam);
   event.parameters.push(amount);
@@ -384,15 +385,15 @@ test("handleSponsored creates a Sponsor", () => {
 
   handleSponsored(event);
 
-  assert.fieldEquals("Sponsor", "1", "amount", "1");
-  assert.fieldEquals("Sponsor", "1", "depositor", MOCK_ADDRESS_1);
-  assert.fieldEquals("Sponsor", "1", "burned", "false");
+  assert.fieldEquals('Sponsor', '1', 'amount', '1');
+  assert.fieldEquals('Sponsor', '1', 'depositor', MOCK_ADDRESS_1);
+  assert.fieldEquals('Sponsor', '1', 'burned', 'false');
 });
 
-test("handleUnsponsored removes a Sponsor by marking as burned", () => {
+test('handleUnsponsored removes a Sponsor by marking as burned', () => {
   clearStore();
 
-  const sponsor = new Sponsor("1");
+  const sponsor = new Sponsor('1');
   sponsor.burned = false;
   sponsor.save();
 
@@ -404,20 +405,20 @@ test("handleUnsponsored removes a Sponsor by marking as burned", () => {
     mockEvent.logType,
     mockEvent.block,
     mockEvent.transaction,
-    mockEvent.parameters
+    mockEvent.parameters,
   );
   event.parameters = new Array();
 
-  const idParam = newI32("id", 1);
+  const idParam = newI32('id', 1);
 
   event.parameters.push(idParam);
 
   handleUnsponsored(event);
 
-  assert.fieldEquals("Sponsor", "1", "burned", "true");
+  assert.fieldEquals('Sponsor', '1', 'burned', 'true');
 });
 
-test("handleDepositMinted creates a Deposit", () => {
+test('handleDepositMinted creates a Deposit', () => {
   clearStore();
 
   let mockEvent = newMockEvent();
@@ -428,22 +429,22 @@ test("handleDepositMinted creates a Deposit", () => {
     mockEvent.logType,
     mockEvent.block,
     mockEvent.transaction,
-    mockEvent.parameters
+    mockEvent.parameters,
   );
   event.parameters = new Array();
 
   const vault = new Vault(mockEvent.address.toHexString());
   vault.save();
 
-  const idParam = newI32("id", 1);
-  const groupId = newI32("groupId", 1);
-  const amount = newI32("amount", 1);
-  const shares = newI32("shares", 1);
-  const depositor = newAddress("depositor", MOCK_ADDRESS_1);
-  const claimer = newAddress("claimer", MOCK_ADDRESS_1);
-  const lockedUntil = newI32("lockedUntil", 1);
-  const data = newBytes("data", Bytes.empty());
-  const name = newString("name", "Foundation");
+  const idParam = newI32('id', 1);
+  const groupId = newI32('groupId', 1);
+  const amount = newI32('amount', 1);
+  const shares = newI32('shares', 1);
+  const depositor = newAddress('depositor', MOCK_ADDRESS_1);
+  const claimer = newAddress('claimer', MOCK_ADDRESS_1);
+  const lockedUntil = newI32('lockedUntil', 1);
+  const data = newBytes('data', Bytes.empty());
+  const name = newString('name', 'Foundation');
 
   event.parameters.push(idParam);
   event.parameters.push(groupId);
@@ -458,23 +459,23 @@ test("handleDepositMinted creates a Deposit", () => {
 
   handleDepositMinted(event);
 
-  assert.fieldEquals("Deposit", "1", "amount", "1");
-  assert.fieldEquals("Deposit", "1", "depositor", MOCK_ADDRESS_1);
-  assert.fieldEquals("Deposit", "1", "claimer", MOCK_ADDRESS_1);
-  assert.fieldEquals("Claimer", MOCK_ADDRESS_1, "principal", "1");
-  assert.fieldEquals("Claimer", MOCK_ADDRESS_1, "depositsIds", "[1]");
+  assert.fieldEquals('Deposit', '1', 'amount', '1');
+  assert.fieldEquals('Deposit', '1', 'depositor', MOCK_ADDRESS_1);
+  assert.fieldEquals('Deposit', '1', 'claimer', MOCK_ADDRESS_1);
+  assert.fieldEquals('Claimer', MOCK_ADDRESS_1, 'principal', '1');
+  assert.fieldEquals('Claimer', MOCK_ADDRESS_1, 'depositsIds', '[1]');
 
   const foundationId = `${vault.id}-1`;
-  assert.fieldEquals("Foundation", foundationId, "name", "Foundation");
-  assert.fieldEquals("Foundation", foundationId, "owner", MOCK_ADDRESS_1);
-  assert.fieldEquals("Foundation", foundationId, "vault", vault.id);
-  assert.fieldEquals("Foundation", foundationId, "amountDeposited", "1");
-  assert.fieldEquals("Foundation", foundationId, "lockedUntil", "1");
+  assert.fieldEquals('Foundation', foundationId, 'name', 'Foundation');
+  assert.fieldEquals('Foundation', foundationId, 'owner', MOCK_ADDRESS_1);
+  assert.fieldEquals('Foundation', foundationId, 'vault', vault.id);
+  assert.fieldEquals('Foundation', foundationId, 'amountDeposited', '1');
+  assert.fieldEquals('Foundation', foundationId, 'lockedUntil', '1');
   assert.fieldEquals(
-    "Foundation",
+    'Foundation',
     foundationId,
-    "createdAt",
-    event.block.timestamp.toString()
+    'createdAt',
+    event.block.timestamp.toString(),
   );
 });
 
@@ -489,23 +490,23 @@ test("handleDepositMinted uses the last event's name as the Foundation's name", 
     mockEvent.logType,
     mockEvent.block,
     mockEvent.transaction,
-    mockEvent.parameters
+    mockEvent.parameters,
   );
   event.parameters = new Array();
 
   const vault = new Vault(mockEvent.address.toHexString());
   vault.save();
 
-  const idParam = newI32("id", 1);
-  const groupId = newI32("groupId", 1);
-  const amount = newI32("amount", 1);
-  const shares = newI32("shares", 1);
-  const depositor = newAddress("depositor", MOCK_ADDRESS_1);
-  const claimer = newAddress("claimer", MOCK_ADDRESS_1);
-  const claimerId = newI32("claimerId", 1);
-  const lockedUntil = newI32("lockedUntil", 1);
-  const data = newBytes("data", Bytes.empty());
-  let name = newString("name", "Foundation");
+  const idParam = newI32('id', 1);
+  const groupId = newI32('groupId', 1);
+  const amount = newI32('amount', 1);
+  const shares = newI32('shares', 1);
+  const depositor = newAddress('depositor', MOCK_ADDRESS_1);
+  const claimer = newAddress('claimer', MOCK_ADDRESS_1);
+  const claimerId = newAddress('claimerId', MOCK_ADDRESS_1);
+  const lockedUntil = newI32('lockedUntil', 1);
+  const data = newBytes('data', Bytes.empty());
+  let name = newString('name', 'Foundation');
 
   event.parameters.push(idParam);
   event.parameters.push(groupId);
@@ -520,8 +521,8 @@ test("handleDepositMinted uses the last event's name as the Foundation's name", 
 
   handleDepositMinted(event);
 
-  const foundationId = `${vault.id}-1`;
-  assert.fieldEquals("Foundation", foundationId, "name", "Foundation");
+  const foundationId = `${mockEvent.address.toHexString()}-1`;
+  assert.fieldEquals('Foundation', foundationId, 'name', 'Foundation');
 
   // Sending another DepositMinted that updates the name
 
@@ -533,11 +534,11 @@ test("handleDepositMinted uses the last event's name as the Foundation's name", 
     mockEvent.logType,
     mockEvent.block,
     mockEvent.transaction,
-    mockEvent.parameters
+    mockEvent.parameters,
   );
   event.parameters = new Array();
 
-  name = newString("name", "Updated Foundation Name");
+  name = newString('name', 'Updated Foundation Name');
 
   event.parameters.push(idParam);
   event.parameters.push(groupId);
@@ -553,34 +554,34 @@ test("handleDepositMinted uses the last event's name as the Foundation's name", 
   handleDepositMinted(event);
 
   assert.fieldEquals(
-    "Foundation",
+    'Foundation',
     foundationId,
-    "name",
-    "Updated Foundation Name"
+    'name',
+    'Updated Foundation Name',
   );
 });
 
-test("handleDepositWithdrawn removes a Deposit by marking as burned", () => {
+test("handleDepositWithdrawn doesn't remove a Deposit for partial withdraws", () => {
   clearStore();
 
   let mockEvent = newMockEvent();
 
-  const claimer = new Claimer("1");
+  const claimer = new Claimer('1');
   claimer.save();
 
-  const deposit = new Deposit("1");
+  const deposit = new Deposit('1');
   deposit.burned = false;
-  deposit.amount = BigInt.fromI32(1);
+  deposit.amount = BigInt.fromI32(10);
   deposit.lockedUntil = BigInt.fromI32(1);
-  deposit.shares = BigInt.fromI32(1);
-  deposit.claimer = "1";
-  deposit.foundation = "1";
+  deposit.shares = BigInt.fromI32(10);
+  deposit.claimer = '1';
+  deposit.foundation = '1';
   deposit.save();
 
   const vault = new Vault(mockEvent.address.toHexString());
   vault.save();
 
-  const foundation = new Foundation("1");
+  const foundation = new Foundation('1');
   foundation.vault = mockEvent.address.toHexString();
   foundation.save();
 
@@ -591,30 +592,81 @@ test("handleDepositWithdrawn removes a Deposit by marking as burned", () => {
     mockEvent.logType,
     mockEvent.block,
     mockEvent.transaction,
-    mockEvent.parameters
+    mockEvent.parameters,
   );
   event.parameters = new Array();
 
-  event.parameters.push(newI32("id", 1));
-  event.parameters.push(newI32("shares", 1));
-  event.parameters.push(newI32("amount", 1));
-  event.parameters.push(newAddress("to", MOCK_ADDRESS_1));
-  event.parameters.push(newBool("burned", true));
+  event.parameters.push(newI32('id', 1));
+  event.parameters.push(newI32('shares', 5));
+  event.parameters.push(newI32('amount', 5));
+  event.parameters.push(newAddress('to', MOCK_ADDRESS_1));
+  event.parameters.push(newBool('burned', false));
 
   handleDepositWithdrawn(event);
 
-  assert.fieldEquals("Deposit", "1", "burned", "true");
-  assert.fieldEquals("Foundation", "1", "amountDeposited", "0");
+  assert.fieldEquals('Deposit', '1', 'burned', 'false');
+  assert.fieldEquals('Deposit', '1', 'shares', '5');
+  assert.fieldEquals('Deposit', '1', 'amount', '5');
+  assert.fieldEquals('Foundation', '1', 'amountDeposited', '0');
 });
 
-test("handleYieldClaimed reduces shares from Deposits and creates Donations", () => {
+test('handleDepositWithdrawn removes a Deposit by marking as burned', () => {
+  clearStore();
+
+  let mockEvent = newMockEvent();
+
+  const claimer = new Claimer('1');
+  claimer.save();
+
+  const deposit = new Deposit('1');
+  deposit.burned = false;
+  deposit.amount = BigInt.fromI32(1);
+  deposit.lockedUntil = BigInt.fromI32(1);
+  deposit.shares = BigInt.fromI32(1);
+  deposit.claimer = '1';
+  deposit.foundation = '1';
+  deposit.save();
+
+  const vault = new Vault(mockEvent.address.toHexString());
+  vault.save();
+
+  const foundation = new Foundation('1');
+  foundation.vault = mockEvent.address.toHexString();
+  foundation.save();
+
+  const event = new DepositWithdrawn(
+    mockEvent.address,
+    mockEvent.logIndex,
+    mockEvent.transactionLogIndex,
+    mockEvent.logType,
+    mockEvent.block,
+    mockEvent.transaction,
+    mockEvent.parameters,
+  );
+  event.parameters = new Array();
+
+  event.parameters.push(newI32('id', 1));
+  event.parameters.push(newI32('shares', 1));
+  event.parameters.push(newI32('amount', 1));
+  event.parameters.push(newAddress('to', MOCK_ADDRESS_1));
+  event.parameters.push(newBool('burned', true));
+
+  handleDepositWithdrawn(event);
+
+  assert.fieldEquals('Deposit', '1', 'burned', 'true');
+  assert.fieldEquals('Deposit', '1', 'shares', '0');
+  assert.fieldEquals('Deposit', '1', 'amount', '0');
+  assert.fieldEquals('Foundation', '1', 'amountDeposited', '0');
+});
+
+test('handleYieldClaimed reduces shares from Deposits and creates Donations', () => {
   clearStore();
 
   let mockEvent = newMockEvent();
 
   // Create deposits
-  createDeposit("1", 50, false, "1", "1", 1, 50);
-  createDeposit("2", 100, false, "1", "1", 1, 100);
+  createDeposit('1', 50, false, '1', '1', 1, 50);
+  createDeposit('2', 100, false, '1', '1', 1, 100);
 
   // Create vault
   const vault = new Vault(mockEvent.address.toHexString());
@@ -624,11 +676,11 @@ test("handleYieldClaimed reduces shares from Deposits and creates Donations", ()
   // Create claimer
   const claimer = new Claimer(MOCK_ADDRESS_1);
   claimer.vault = mockEvent.address.toHexString();
-  claimer.depositsIds = ["1", "2"];
+  claimer.depositsIds = ['1', '2'];
   claimer.save();
 
   // Create foundation
-  const foundation = new Foundation("1");
+  const foundation = new Foundation('1');
   foundation.vault = mockEvent.address.toHexString();
   foundation.save();
 
@@ -639,35 +691,35 @@ test("handleYieldClaimed reduces shares from Deposits and creates Donations", ()
     mockEvent.logType,
     mockEvent.block,
     mockEvent.transaction,
-    mockEvent.parameters
+    mockEvent.parameters,
   );
   event.parameters = new Array();
 
-  event.parameters.push(newAddress("claimerId", MOCK_ADDRESS_1));
-  event.parameters.push(newAddress("to", TREASURY_ADDRESS));
-  event.parameters.push(newI32("amount", 150));
-  event.parameters.push(newI32("burnedShares", 75));
-  event.parameters.push(newI32("perfFee", 0));
+  event.parameters.push(newAddress('claimerId', MOCK_ADDRESS_1));
+  event.parameters.push(newAddress('to', TREASURY_ADDRESS));
+  event.parameters.push(newI32('amount', 150));
+  event.parameters.push(newI32('burnedShares', 75));
+  event.parameters.push(newI32('perfFee', 0));
 
   handleYieldClaimed(event);
 
-  assert.fieldEquals("Deposit", "1", "shares", "25");
-  assert.fieldEquals("Deposit", "2", "shares", "50");
+  assert.fieldEquals('Deposit', '1', 'shares', '25');
+  assert.fieldEquals('Deposit', '2', 'shares', '50');
 
-  assert.fieldEquals("Donation", donationId(mockEvent, "0"), "amount", "50");
-  assert.fieldEquals("Donation", donationId(mockEvent, "1"), "amount", "100");
+  assert.fieldEquals('Donation', donationId(mockEvent, '0'), 'amount', '50');
+  assert.fieldEquals('Donation', donationId(mockEvent, '1'), 'amount', '100');
 
   clearStore();
 });
 
-test("handleYieldClaimed takes the performance fee into account", () => {
+test('handleYieldClaimed takes the performance fee into account', () => {
   clearStore();
 
   let mockEvent = newMockEvent();
 
   // Create deposits
-  createDeposit("1", 50, false, "1", "1", 1, 50);
-  createDeposit("2", 100, false, "1", "1", 1, 100);
+  createDeposit('1', 50, false, '1', '1', 1, 50);
+  createDeposit('2', 100, false, '1', '1', 1, 100);
 
   // Create vault
   const vault = new Vault(mockEvent.address.toHexString());
@@ -677,11 +729,11 @@ test("handleYieldClaimed takes the performance fee into account", () => {
   // Create claimer
   const claimer = new Claimer(MOCK_ADDRESS_1);
   claimer.vault = mockEvent.address.toHexString();
-  claimer.depositsIds = ["1", "2"];
+  claimer.depositsIds = ['1', '2'];
   claimer.save();
 
   // Create foundation
-  const foundation = new Foundation("1");
+  const foundation = new Foundation('1');
   foundation.vault = mockEvent.address.toHexString();
   foundation.save();
 
@@ -692,25 +744,25 @@ test("handleYieldClaimed takes the performance fee into account", () => {
     mockEvent.logType,
     mockEvent.block,
     mockEvent.transaction,
-    mockEvent.parameters
+    mockEvent.parameters,
   );
   event.parameters = new Array();
 
-  event.parameters.push(newAddress("claimerId", MOCK_ADDRESS_1));
-  event.parameters.push(newAddress("to", TREASURY_ADDRESS));
-  event.parameters.push(newI32("amount", 120));
-  event.parameters.push(newI32("burnedShares", 75));
-  event.parameters.push(newI32("perfFee", 30));
+  event.parameters.push(newAddress('claimerId', MOCK_ADDRESS_1));
+  event.parameters.push(newAddress('to', TREASURY_ADDRESS));
+  event.parameters.push(newI32('amount', 120));
+  event.parameters.push(newI32('burnedShares', 75));
+  event.parameters.push(newI32('perfFee', 30));
 
   handleYieldClaimed(event);
 
-  assert.fieldEquals("Claimer", MOCK_ADDRESS_1, "claimed", "120");
+  assert.fieldEquals('Claimer', MOCK_ADDRESS_1, 'claimed', '120');
 
-  assert.fieldEquals("Deposit", "1", "shares", "25");
-  assert.fieldEquals("Deposit", "2", "shares", "50");
+  assert.fieldEquals('Deposit', '1', 'shares', '25');
+  assert.fieldEquals('Deposit', '2', 'shares', '50');
 
-  assert.fieldEquals("Donation", donationId(mockEvent, "0"), "amount", "40");
-  assert.fieldEquals("Donation", donationId(mockEvent, "1"), "amount", "80");
+  assert.fieldEquals('Donation', donationId(mockEvent, '0'), 'amount', '40');
+  assert.fieldEquals('Donation', donationId(mockEvent, '1'), 'amount', '80');
 
   clearStore();
 });
@@ -721,8 +773,8 @@ test("handleYieldClaimed doesn't create donations if the deposits are not to the
   let mockEvent = newMockEvent();
 
   // Create deposits
-  createDeposit("1", 50, false, "1", "1", 1, 50);
-  createDeposit("2", 100, false, "1", "1", 1, 100);
+  createDeposit('1', 50, false, '1', '1', 1, 50);
+  createDeposit('2', 100, false, '1', '1', 1, 100);
 
   // Create vault
   const vault = new Vault(mockEvent.address.toHexString());
@@ -732,11 +784,11 @@ test("handleYieldClaimed doesn't create donations if the deposits are not to the
   // Create claimer
   const claimer = new Claimer(MOCK_ADDRESS_2);
   claimer.vault = mockEvent.address.toHexString();
-  claimer.depositsIds = ["1", "2"];
+  claimer.depositsIds = ['1', '2'];
   claimer.save();
 
   // Create foundation
-  const foundation = new Foundation("1");
+  const foundation = new Foundation('1');
   foundation.vault = mockEvent.address.toHexString();
   foundation.save();
 
@@ -747,32 +799,32 @@ test("handleYieldClaimed doesn't create donations if the deposits are not to the
     mockEvent.logType,
     mockEvent.block,
     mockEvent.transaction,
-    mockEvent.parameters
+    mockEvent.parameters,
   );
   event.parameters = new Array();
 
-  event.parameters.push(newAddress("claimerId", MOCK_ADDRESS_2));
-  event.parameters.push(newAddress("to", MOCK_ADDRESS_1));
-  event.parameters.push(newI32("amount", 150));
-  event.parameters.push(newI32("burnedShares", 75));
-  event.parameters.push(newI32("perfFee", 0));
+  event.parameters.push(newAddress('claimerId', MOCK_ADDRESS_2));
+  event.parameters.push(newAddress('to', MOCK_ADDRESS_1));
+  event.parameters.push(newI32('amount', 150));
+  event.parameters.push(newI32('burnedShares', 75));
+  event.parameters.push(newI32('perfFee', 0));
 
   handleYieldClaimed(event);
 
-  assert.notInStore("Donation", donationId(mockEvent, "0"));
-  assert.notInStore("Donation", donationId(mockEvent, "1"));
+  assert.notInStore('Donation', donationId(mockEvent, '0'));
+  assert.notInStore('Donation', donationId(mockEvent, '1'));
 
   clearStore();
 });
 
-test("handleYieldClaimed handles scenarios where only one of the deposits generated yield", () => {
+test('handleYieldClaimed handles scenarios where only one of the deposits generated yield', () => {
   clearStore();
 
   let mockEvent = newMockEvent();
 
   // Create deposits
-  createDeposit("1", 50, false, "1", "1", 1, 50);
-  createDeposit("2", 100, false, "1", "1", 1, 50);
+  createDeposit('1', 50, false, '1', '1', 1, 50);
+  createDeposit('2', 100, false, '1', '1', 1, 50);
 
   const vault = new Vault(mockEvent.address.toHexString());
   vault.treasury = Address.fromString(TREASURY_ADDRESS);
@@ -780,10 +832,10 @@ test("handleYieldClaimed handles scenarios where only one of the deposits genera
 
   const claimer = new Claimer(MOCK_ADDRESS_2);
   claimer.vault = mockEvent.address.toHexString();
-  claimer.depositsIds = ["1", "2"];
+  claimer.depositsIds = ['1', '2'];
   claimer.save();
 
-  const foundation = new Foundation("1");
+  const foundation = new Foundation('1');
   foundation.vault = mockEvent.address.toHexString();
   foundation.save();
 
@@ -794,31 +846,31 @@ test("handleYieldClaimed handles scenarios where only one of the deposits genera
     mockEvent.logType,
     mockEvent.block,
     mockEvent.transaction,
-    mockEvent.parameters
+    mockEvent.parameters,
   );
   event.parameters = new Array();
 
-  event.parameters.push(newAddress("claimerId", MOCK_ADDRESS_2));
-  event.parameters.push(newAddress("to", TREASURY_ADDRESS));
-  event.parameters.push(newI32("amount", 50));
-  event.parameters.push(newI32("burnedShares", 25));
-  event.parameters.push(newI32("perfFee", 0));
+  event.parameters.push(newAddress('claimerId', MOCK_ADDRESS_2));
+  event.parameters.push(newAddress('to', TREASURY_ADDRESS));
+  event.parameters.push(newI32('amount', 50));
+  event.parameters.push(newI32('burnedShares', 25));
+  event.parameters.push(newI32('perfFee', 0));
 
   handleYieldClaimed(event);
 
-  assert.fieldEquals("Deposit", "1", "shares", "25");
-  assert.fieldEquals("Deposit", "2", "shares", "50");
+  assert.fieldEquals('Deposit', '1', 'shares', '25');
+  assert.fieldEquals('Deposit', '2', 'shares', '50');
 
-  assert.fieldEquals("Donation", donationId(mockEvent, "0"), "amount", "50");
+  assert.fieldEquals('Donation', donationId(mockEvent, '0'), 'amount', '50');
 });
 
-test("handleYieldClaimed handles scenarios where the yield is not proportional to the deposit shares", () => {
+test('handleYieldClaimed handles scenarios where the yield is not proportional to the deposit shares', () => {
   clearStore();
 
   let mockEvent = newMockEvent();
 
-  createDeposit("1", 50, false, "1", "1", 1, 50);
-  createDeposit("2", 100, false, "1", "1", 1, 50);
+  createDeposit('1', 50, false, '1', '1', 1, 50);
+  createDeposit('2', 100, false, '1', '1', 1, 50);
 
   const vault = new Vault(mockEvent.address.toHexString());
   vault.treasury = Address.fromString(TREASURY_ADDRESS);
@@ -826,10 +878,10 @@ test("handleYieldClaimed handles scenarios where the yield is not proportional t
 
   const claimer = new Claimer(MOCK_ADDRESS_2);
   claimer.vault = mockEvent.address.toHexString();
-  claimer.depositsIds = ["1", "2"];
+  claimer.depositsIds = ['1', '2'];
   claimer.save();
 
-  const foundation = new Foundation("1");
+  const foundation = new Foundation('1');
   foundation.vault = mockEvent.address.toHexString();
   foundation.save();
 
@@ -840,23 +892,23 @@ test("handleYieldClaimed handles scenarios where the yield is not proportional t
     mockEvent.logType,
     mockEvent.block,
     mockEvent.transaction,
-    mockEvent.parameters
+    mockEvent.parameters,
   );
   event.parameters = new Array();
 
-  event.parameters.push(newAddress("claimerId", MOCK_ADDRESS_2));
-  event.parameters.push(newAddress("to", TREASURY_ADDRESS));
-  event.parameters.push(newI32("amount", 147));
-  event.parameters.push(newI32("burnedShares", 49));
-  event.parameters.push(newI32("perfFee", 0));
+  event.parameters.push(newAddress('claimerId', MOCK_ADDRESS_2));
+  event.parameters.push(newAddress('to', TREASURY_ADDRESS));
+  event.parameters.push(newI32('amount', 147));
+  event.parameters.push(newI32('burnedShares', 49));
+  event.parameters.push(newI32('perfFee', 0));
 
   handleYieldClaimed(event);
 
-  assert.fieldEquals("Deposit", "1", "shares", "17");
-  assert.fieldEquals("Deposit", "2", "shares", "34");
+  assert.fieldEquals('Deposit', '1', 'shares', '17');
+  assert.fieldEquals('Deposit', '2', 'shares', '34');
 
-  assert.fieldEquals("Donation", donationId(mockEvent, "0"), "amount", "99");
-  assert.fieldEquals("Donation", donationId(mockEvent, "1"), "amount", "48");
+  assert.fieldEquals('Donation', donationId(mockEvent, '0'), 'amount', '99');
+  assert.fieldEquals('Donation', donationId(mockEvent, '1'), 'amount', '48');
 });
 
 function newBytes(name: string, value: Bytes): ethereum.EventParam {
@@ -874,7 +926,7 @@ function newBool(name: string, value: bool): ethereum.EventParam {
 function newAddress(name: string, value: string): ethereum.EventParam {
   return new ethereum.EventParam(
     name,
-    ethereum.Value.fromAddress(Address.fromString(value))
+    ethereum.Value.fromAddress(Address.fromString(value)),
   );
 }
 
@@ -884,7 +936,7 @@ function newString(name: string, value: string): ethereum.EventParam {
 
 function donationId(event: ethereum.Event, id: string): string {
   return (
-    event.transaction.hash.toHex() + "-" + event.logIndex.toString() + "-" + id
+    event.transaction.hash.toHex() + '-' + event.logIndex.toString() + '-' + id
   );
 }
 
@@ -895,7 +947,7 @@ function createDeposit(
   claimer: string,
   foundation: string,
   lockedUntil: i32,
-  shares: i32
+  shares: i32,
 ): void {
   const deposit = new Deposit(id);
   deposit.amount = BigInt.fromI32(amount);

--- a/subgraph/tests/integration.test.ts
+++ b/subgraph/tests/integration.test.ts
@@ -1,11 +1,20 @@
-import { ethereum, Address, Bytes, BigInt } from '@graphprotocol/graph-ts';
-import { log } from 'matchstick-as/assembly/log';
+import { Address, Bytes, BigInt } from '@graphprotocol/graph-ts';
 import {
   test,
   assert,
   newMockEvent,
   clearStore,
 } from 'matchstick-as/assembly/index';
+
+import {
+  newBytes,
+  newI32,
+  newBool,
+  newAddress,
+  newString,
+  donationId,
+  createDeposit,
+} from './helpers';
 
 import {
   handleDepositMinted,
@@ -52,373 +61,7 @@ const MOCK_ADDRESS_1 = '0xC80B3caAd6d2DE80Ac76a41d5F0072E36D2519Cd'.toLowerCase(
 const MOCK_ADDRESS_2 = '0xE80B3caAd6d2DE80Ac76a41d5F0072E36D2519Ce'.toLowerCase();
 const TREASURY_ADDRESS = '0x4940c6e628da11ac0bdcf7f82be8579b4696fa33';
 
-test('handleInitDeposit creates a DepositOperation', () => {
-  clearStore();
-
-  let mockEvent = newMockEvent();
-  const event = new InitDepositStable(
-    mockEvent.address,
-    mockEvent.logIndex,
-    mockEvent.transactionLogIndex,
-    mockEvent.logType,
-    mockEvent.block,
-    mockEvent.transaction,
-    mockEvent.parameters,
-  );
-  event.parameters = new Array();
-
-  const operator = newAddress('operator', MOCK_ADDRESS_1);
-  const idx = newI32('idx', 1);
-  const underlyingAmount = newI32('underlyingAmount', 1);
-  const ustAmount = newI32('ustAmount', 1);
-
-  event.parameters.push(operator);
-  event.parameters.push(idx);
-  event.parameters.push(ustAmount);
-  event.parameters.push(underlyingAmount);
-
-  handleInitDeposit(event);
-
-  assert.fieldEquals('DepositOperation', MOCK_ADDRESS_1, 'idx', '1');
-  assert.fieldEquals(
-    'DepositOperation',
-    MOCK_ADDRESS_1,
-    'underlyingAmount',
-    '1',
-  );
-  assert.fieldEquals('DepositOperation', MOCK_ADDRESS_1, 'ustAmount', '1');
-});
-
-test('RearrangeDepositOperation updates the DepositOperation idx', () => {
-  clearStore();
-
-  let mockDepositEvent = newMockEvent();
-  const depositEvent = new InitDepositStable(
-    mockDepositEvent.address,
-    mockDepositEvent.logIndex,
-    mockDepositEvent.transactionLogIndex,
-    mockDepositEvent.logType,
-    mockDepositEvent.block,
-    mockDepositEvent.transaction,
-    mockDepositEvent.parameters,
-  );
-  depositEvent.parameters = new Array();
-
-  let operator = newAddress('operator', MOCK_ADDRESS_1);
-  let idx = newI32('idx', 1);
-  let underlyingAmount = newI32('underlyingAmount', 1);
-  let ustAmount = newI32('ustAmount', 1);
-
-  depositEvent.parameters.push(operator);
-  depositEvent.parameters.push(idx);
-  depositEvent.parameters.push(ustAmount);
-  depositEvent.parameters.push(underlyingAmount);
-
-  handleInitDeposit(depositEvent);
-
-  let mockDepositEvent1 = newMockEvent();
-  const depositEvent1 = new InitDepositStable(
-    mockDepositEvent1.address,
-    mockDepositEvent1.logIndex,
-    mockDepositEvent1.transactionLogIndex,
-    mockDepositEvent1.logType,
-    mockDepositEvent1.block,
-    mockDepositEvent1.transaction,
-    mockDepositEvent1.parameters,
-  );
-  depositEvent1.parameters = new Array();
-
-  operator = newAddress('operator', MOCK_ADDRESS_2);
-  idx = newI32('idx', 2);
-
-  depositEvent1.parameters.push(operator);
-  depositEvent1.parameters.push(idx);
-  depositEvent1.parameters.push(ustAmount);
-  depositEvent1.parameters.push(underlyingAmount);
-
-  handleInitDeposit(depositEvent1);
-
-  let mockEvent = newMockEvent();
-  const event = new RearrangeDepositOperation(
-    mockEvent.address,
-    mockEvent.logIndex,
-    mockEvent.transactionLogIndex,
-    mockEvent.logType,
-    mockEvent.block,
-    mockEvent.transaction,
-    mockEvent.parameters,
-  );
-  event.parameters = new Array();
-
-  const operatorFrom = newAddress('operatorFrom', MOCK_ADDRESS_2);
-  const operatorTo = newAddress('operatorTo', MOCK_ADDRESS_1);
-  idx = newI32('idx', 1);
-
-  event.parameters.push(operatorFrom);
-  event.parameters.push(operatorTo);
-  event.parameters.push(idx);
-
-  assert.fieldEquals('DepositOperation', MOCK_ADDRESS_2, 'idx', '2');
-  assert.fieldEquals('DepositOperation', MOCK_ADDRESS_1, 'idx', '1');
-
-  handleRearrangeDeposit(event);
-
-  assert.fieldEquals('DepositOperation', MOCK_ADDRESS_2, 'idx', '1');
-  assert.fieldEquals('DepositOperation', MOCK_ADDRESS_1, 'idx', '1');
-});
-
-test('handleFinishDeposit deletes the DepositOperation', () => {
-  clearStore();
-
-  const depositOperation = new DepositOperation(MOCK_ADDRESS_1);
-  depositOperation.save();
-
-  let mockEvent = newMockEvent();
-  const event = new FinishDepositStable(
-    mockEvent.address,
-    mockEvent.logIndex,
-    mockEvent.transactionLogIndex,
-    mockEvent.logType,
-    mockEvent.block,
-    mockEvent.transaction,
-    mockEvent.parameters,
-  );
-  event.parameters = new Array();
-
-  const operator = newAddress('operator', MOCK_ADDRESS_1);
-
-  event.parameters.push(operator);
-
-  handleFinishDeposit(event);
-
-  assert.notInStore('DepositOperation', MOCK_ADDRESS_1);
-});
-
-test('handleInitRedeem creates a RedeemOperation', () => {
-  clearStore();
-
-  let mockEvent = newMockEvent();
-  const event = new InitRedeemStable(
-    mockEvent.address,
-    mockEvent.logIndex,
-    mockEvent.transactionLogIndex,
-    mockEvent.logType,
-    mockEvent.block,
-    mockEvent.transaction,
-    mockEvent.parameters,
-  );
-  event.parameters = new Array();
-
-  const operator = newAddress('operator', MOCK_ADDRESS_1);
-  const idx = newI32('idx', 1);
-  const aUstAmount = newI32('aUstAmount', 1);
-
-  event.parameters.push(operator);
-  event.parameters.push(idx);
-  event.parameters.push(aUstAmount);
-
-  handleInitRedeem(event);
-
-  assert.fieldEquals('RedeemOperation', MOCK_ADDRESS_1, 'aUstAmount', '1');
-});
-
-test('RearrangeRedeemOperation updates the RedeemOperation idx', () => {
-  clearStore();
-
-  let mockRedeemEvent = newMockEvent();
-  const redeemEvent = new InitRedeemStable(
-    mockRedeemEvent.address,
-    mockRedeemEvent.logIndex,
-    mockRedeemEvent.transactionLogIndex,
-    mockRedeemEvent.logType,
-    mockRedeemEvent.block,
-    mockRedeemEvent.transaction,
-    mockRedeemEvent.parameters,
-  );
-  redeemEvent.parameters = new Array();
-
-  let operator = newAddress('operator', MOCK_ADDRESS_1);
-  let aUstAmount = newI32('aUstAmount', 1);
-  let idx = newI32('idx', 1);
-
-  redeemEvent.parameters.push(operator);
-  redeemEvent.parameters.push(idx);
-  redeemEvent.parameters.push(aUstAmount);
-
-  handleInitRedeem(redeemEvent);
-
-  let mockRedeemEvent1 = newMockEvent();
-  const redeemEvent1 = new InitRedeemStable(
-    mockRedeemEvent1.address,
-    mockRedeemEvent1.logIndex,
-    mockRedeemEvent1.transactionLogIndex,
-    mockRedeemEvent1.logType,
-    mockRedeemEvent1.block,
-    mockRedeemEvent1.transaction,
-    mockRedeemEvent1.parameters,
-  );
-  redeemEvent1.parameters = new Array();
-
-  operator = newAddress('operator', MOCK_ADDRESS_2);
-  idx = newI32('idx', 2);
-
-  redeemEvent1.parameters.push(operator);
-  redeemEvent1.parameters.push(idx);
-  redeemEvent1.parameters.push(aUstAmount);
-
-  handleInitRedeem(redeemEvent1);
-
-  const mockEvent = newMockEvent();
-  const event = new RearrangeRedeemOperation(
-    mockEvent.address,
-    mockEvent.logIndex,
-    mockEvent.transactionLogIndex,
-    mockEvent.logType,
-    mockEvent.block,
-    mockEvent.transaction,
-    mockEvent.parameters,
-  );
-  event.parameters = new Array();
-
-  const operatorFrom = newAddress('operatorFrom', MOCK_ADDRESS_2);
-  const operatorTo = newAddress('operatorTo', MOCK_ADDRESS_1);
-  idx = newI32('idx', 1);
-
-  event.parameters.push(operatorFrom);
-  event.parameters.push(operatorTo);
-  event.parameters.push(idx);
-
-  assert.fieldEquals('RedeemOperation', MOCK_ADDRESS_2, 'idx', '2');
-  assert.fieldEquals('RedeemOperation', MOCK_ADDRESS_1, 'idx', '1');
-
-  handleRearrangeRedeem(event);
-
-  assert.fieldEquals('RedeemOperation', MOCK_ADDRESS_2, 'idx', '1');
-  assert.fieldEquals('RedeemOperation', MOCK_ADDRESS_1, 'idx', '1');
-});
-
-test('handleFinishRedeem updates the RedeemOperation', () => {
-  clearStore();
-
-  const depositOperation = new RedeemOperation(MOCK_ADDRESS_1);
-  depositOperation.save();
-
-  let mockEvent = newMockEvent();
-  const event = new FinishRedeemStable(
-    mockEvent.address,
-    mockEvent.logIndex,
-    mockEvent.transactionLogIndex,
-    mockEvent.logType,
-    mockEvent.block,
-    mockEvent.transaction,
-    mockEvent.parameters,
-  );
-  event.parameters = new Array();
-
-  const operator = newAddress('operator', MOCK_ADDRESS_1);
-
-  event.parameters.push(operator);
-
-  handleFinishRedeem(event);
-
-  assert.notInStore('RedeemOperation', MOCK_ADDRESS_1);
-});
-
-test('handleTreasuryUpdated updates the treasury', () => {
-  clearStore();
-
-  let mockEvent = newMockEvent();
-  const event = new TreasuryUpdated(
-    mockEvent.address,
-    mockEvent.logIndex,
-    mockEvent.transactionLogIndex,
-    mockEvent.logType,
-    mockEvent.block,
-    mockEvent.transaction,
-    mockEvent.parameters,
-  );
-  event.parameters = new Array();
-
-  const treasury = newAddress('treasury', MOCK_ADDRESS_1);
-  event.parameters.push(treasury);
-
-  // create vault
-  const vault = new Vault(mockEvent.address.toHexString());
-  vault.save();
-
-  handleTreasuryUpdated(event);
-
-  assert.fieldEquals(
-    'Vault',
-    mockEvent.address.toHexString(),
-    'treasury',
-    MOCK_ADDRESS_1,
-  );
-});
-
-test('handleSponsored creates a Sponsor', () => {
-  clearStore();
-
-  let mockEvent = newMockEvent();
-  const event = new Sponsored(
-    mockEvent.address,
-    mockEvent.logIndex,
-    mockEvent.transactionLogIndex,
-    mockEvent.logType,
-    mockEvent.block,
-    mockEvent.transaction,
-    mockEvent.parameters,
-  );
-  event.parameters = new Array();
-
-  const idParam = newI32('id', 1);
-  const amount = newI32('amount', 1);
-  const depositor = newAddress('depositor', MOCK_ADDRESS_1);
-  const lockedUntil = newI32('lockedUntil', 1);
-  const burned = newBool('burned', false);
-
-  event.parameters.push(idParam);
-  event.parameters.push(amount);
-  event.parameters.push(depositor);
-  event.parameters.push(lockedUntil);
-  event.parameters.push(burned);
-
-  handleSponsored(event);
-
-  assert.fieldEquals('Sponsor', '1', 'amount', '1');
-  assert.fieldEquals('Sponsor', '1', 'depositor', MOCK_ADDRESS_1);
-  assert.fieldEquals('Sponsor', '1', 'burned', 'false');
-});
-
-test('handleUnsponsored removes a Sponsor by marking as burned', () => {
-  clearStore();
-
-  const sponsor = new Sponsor('1');
-  sponsor.burned = false;
-  sponsor.save();
-
-  let mockEvent = newMockEvent();
-  const event = new Unsponsored(
-    mockEvent.address,
-    mockEvent.logIndex,
-    mockEvent.transactionLogIndex,
-    mockEvent.logType,
-    mockEvent.block,
-    mockEvent.transaction,
-    mockEvent.parameters,
-  );
-  event.parameters = new Array();
-
-  const idParam = newI32('id', 1);
-
-  event.parameters.push(idParam);
-
-  handleUnsponsored(event);
-
-  assert.fieldEquals('Sponsor', '1', 'burned', 'true');
-});
-
-test('handleDepositMinted creates a Deposit', () => {
+test('handleDepositMinted updates the Foundation', () => {
   clearStore();
 
   let mockEvent = newMockEvent();
@@ -436,76 +79,14 @@ test('handleDepositMinted creates a Deposit', () => {
   const vault = new Vault(mockEvent.address.toHexString());
   vault.save();
 
-  const idParam = newI32('id', 1);
+  let idParam = newI32('id', 1);
   const groupId = newI32('groupId', 1);
-  const amount = newI32('amount', 1);
-  const shares = newI32('shares', 1);
-  const depositor = newAddress('depositor', MOCK_ADDRESS_1);
-  const claimer = newAddress('claimer', MOCK_ADDRESS_1);
-  const lockedUntil = newI32('lockedUntil', 1);
-  const data = newBytes('data', Bytes.empty());
-  const name = newString('name', 'Foundation');
-
-  event.parameters.push(idParam);
-  event.parameters.push(groupId);
-  event.parameters.push(amount);
-  event.parameters.push(shares);
-  event.parameters.push(depositor);
-  event.parameters.push(claimer);
-  event.parameters.push(claimer);
-  event.parameters.push(lockedUntil);
-  event.parameters.push(data);
-  event.parameters.push(name);
-
-  handleDepositMinted(event);
-
-  assert.fieldEquals('Deposit', '1', 'amount', '1');
-  assert.fieldEquals('Deposit', '1', 'depositor', MOCK_ADDRESS_1);
-  assert.fieldEquals('Deposit', '1', 'claimer', MOCK_ADDRESS_1);
-  assert.fieldEquals('Claimer', MOCK_ADDRESS_1, 'principal', '1');
-  assert.fieldEquals('Claimer', MOCK_ADDRESS_1, 'depositsIds', '[1]');
-
-  const foundationId = `${vault.id}-1`;
-  assert.fieldEquals('Foundation', foundationId, 'name', 'Foundation');
-  assert.fieldEquals('Foundation', foundationId, 'owner', MOCK_ADDRESS_1);
-  assert.fieldEquals('Foundation', foundationId, 'vault', vault.id);
-  assert.fieldEquals('Foundation', foundationId, 'amountDeposited', '1');
-  assert.fieldEquals('Foundation', foundationId, 'lockedUntil', '1');
-  assert.fieldEquals(
-    'Foundation',
-    foundationId,
-    'createdAt',
-    event.block.timestamp.toString(),
-  );
-});
-
-test("handleDepositMinted uses the last event's name as the Foundation's name", () => {
-  clearStore();
-
-  let mockEvent = newMockEvent();
-  let event = new DepositMinted(
-    mockEvent.address,
-    mockEvent.logIndex,
-    mockEvent.transactionLogIndex,
-    mockEvent.logType,
-    mockEvent.block,
-    mockEvent.transaction,
-    mockEvent.parameters,
-  );
-  event.parameters = new Array();
-
-  const vault = new Vault(mockEvent.address.toHexString());
-  vault.save();
-
-  const idParam = newI32('id', 1);
-  const groupId = newI32('groupId', 1);
-  const amount = newI32('amount', 1);
-  const shares = newI32('shares', 1);
-  const depositor = newAddress('depositor', MOCK_ADDRESS_1);
-  const claimer = newAddress('claimer', MOCK_ADDRESS_1);
-  const claimerId = newAddress('claimerId', MOCK_ADDRESS_1);
-  const lockedUntil = newI32('lockedUntil', 1);
-  const data = newBytes('data', Bytes.empty());
+  let amount = newI32('amount', 10);
+  let shares = newI32('shares', 10);
+  let depositor = newAddress('depositor', MOCK_ADDRESS_1);
+  let claimer = newAddress('claimer', MOCK_ADDRESS_1);
+  let lockedUntil = newI32('lockedUntil', 1);
+  let data = newBytes('data', Bytes.empty());
   let name = newString('name', 'Foundation');
 
   event.parameters.push(idParam);
@@ -514,78 +95,32 @@ test("handleDepositMinted uses the last event's name as the Foundation's name", 
   event.parameters.push(shares);
   event.parameters.push(depositor);
   event.parameters.push(claimer);
-  event.parameters.push(claimerId);
-  event.parameters.push(lockedUntil);
-  event.parameters.push(data);
-  event.parameters.push(name);
-
-  handleDepositMinted(event);
-
-  const foundationId = `${mockEvent.address.toHexString()}-1`;
-  assert.fieldEquals('Foundation', foundationId, 'name', 'Foundation');
-
-  // Sending another DepositMinted that updates the name
-
-  mockEvent = newMockEvent();
-  event = new DepositMinted(
-    mockEvent.address,
-    mockEvent.logIndex,
-    mockEvent.transactionLogIndex,
-    mockEvent.logType,
-    mockEvent.block,
-    mockEvent.transaction,
-    mockEvent.parameters,
-  );
-  event.parameters = new Array();
-
-  name = newString('name', 'Updated Foundation Name');
-
-  event.parameters.push(idParam);
-  event.parameters.push(groupId);
-  event.parameters.push(amount);
-  event.parameters.push(shares);
-  event.parameters.push(depositor);
   event.parameters.push(claimer);
-  event.parameters.push(claimerId);
   event.parameters.push(lockedUntil);
   event.parameters.push(data);
   event.parameters.push(name);
 
   handleDepositMinted(event);
 
+  const foundationId = `${vault.id}-1`;
+
+  assert.fieldEquals('Foundation', foundationId, 'name', 'Foundation');
+  assert.fieldEquals('Foundation', foundationId, 'owner', MOCK_ADDRESS_1);
+  assert.fieldEquals('Foundation', foundationId, 'vault', vault.id);
+  assert.fieldEquals('Foundation', foundationId, 'amountDeposited', '10');
+  assert.fieldEquals('Foundation', foundationId, 'shares', '10');
+  assert.fieldEquals('Foundation', foundationId, 'lockedUntil', '1');
   assert.fieldEquals(
     'Foundation',
     foundationId,
-    'name',
-    'Updated Foundation Name',
+    'createdAt',
+    event.block.timestamp.toString(),
   );
-});
 
-test("handleDepositWithdrawn doesn't remove a Deposit for partial withdraws", () => {
-  clearStore();
+  // Second deposit
 
-  let mockEvent = newMockEvent();
-
-  const claimer = new Claimer('1');
-  claimer.save();
-
-  const deposit = new Deposit('1');
-  deposit.burned = false;
-  deposit.amount = BigInt.fromI32(10);
-  deposit.lockedUntil = BigInt.fromI32(1);
-  deposit.shares = BigInt.fromI32(10);
-  deposit.claimer = '1';
-  deposit.foundation = '1';
-  deposit.save();
-
-  const vault = new Vault(mockEvent.address.toHexString());
-  vault.save();
-
-  const foundation = new Foundation('1');
-  foundation.vault = mockEvent.address.toHexString();
-  foundation.save();
-
-  const event = new DepositWithdrawn(
+  mockEvent = newMockEvent();
+  const event2 = new DepositMinted(
     mockEvent.address,
     mockEvent.logIndex,
     mockEvent.transactionLogIndex,
@@ -594,227 +129,42 @@ test("handleDepositWithdrawn doesn't remove a Deposit for partial withdraws", ()
     mockEvent.transaction,
     mockEvent.parameters,
   );
-  event.parameters = new Array();
+  event2.parameters = new Array();
 
-  event.parameters.push(newI32('id', 1));
-  event.parameters.push(newI32('shares', 5));
-  event.parameters.push(newI32('amount', 5));
-  event.parameters.push(newAddress('to', MOCK_ADDRESS_1));
-  event.parameters.push(newBool('burned', false));
+  idParam = newI32('id', 1);
+  amount = newI32('amount', 20);
+  shares = newI32('shares', 15);
+  depositor = newAddress('depositor', MOCK_ADDRESS_1);
+  claimer = newAddress('claimer', MOCK_ADDRESS_1);
+  lockedUntil = newI32('lockedUntil', 2);
+  data = newBytes('data', Bytes.empty());
+  name = newString('name', 'Foundation 2');
 
-  handleDepositWithdrawn(event);
+  event2.parameters.push(idParam);
+  event2.parameters.push(groupId);
+  event2.parameters.push(amount);
+  event2.parameters.push(shares);
+  event2.parameters.push(depositor);
+  event2.parameters.push(claimer);
+  event2.parameters.push(claimer);
+  event2.parameters.push(lockedUntil);
+  event2.parameters.push(data);
+  event2.parameters.push(name);
 
-  assert.fieldEquals('Deposit', '1', 'burned', 'false');
-  assert.fieldEquals('Deposit', '1', 'shares', '5');
-  assert.fieldEquals('Deposit', '1', 'amount', '5');
-  assert.fieldEquals('Foundation', '1', 'amountDeposited', '0');
-});
+  handleDepositMinted(event2);
 
-test('handleDepositWithdrawn removes a Deposit by marking as burned', () => {
-  clearStore();
-
-  let mockEvent = newMockEvent();
-
-  const claimer = new Claimer('1');
-  claimer.save();
-
-  const deposit = new Deposit('1');
-  deposit.burned = false;
-  deposit.amount = BigInt.fromI32(1);
-  deposit.lockedUntil = BigInt.fromI32(1);
-  deposit.shares = BigInt.fromI32(1);
-  deposit.claimer = '1';
-  deposit.foundation = '1';
-  deposit.save();
-
-  const vault = new Vault(mockEvent.address.toHexString());
-  vault.save();
-
-  const foundation = new Foundation('1');
-  foundation.vault = mockEvent.address.toHexString();
-  foundation.save();
-
-  const event = new DepositWithdrawn(
-    mockEvent.address,
-    mockEvent.logIndex,
-    mockEvent.transactionLogIndex,
-    mockEvent.logType,
-    mockEvent.block,
-    mockEvent.transaction,
-    mockEvent.parameters,
+  assert.fieldEquals('Foundation', foundationId, 'name', 'Foundation 2');
+  assert.fieldEquals('Foundation', foundationId, 'owner', MOCK_ADDRESS_1);
+  assert.fieldEquals('Foundation', foundationId, 'vault', vault.id);
+  assert.fieldEquals('Foundation', foundationId, 'amountDeposited', '30');
+  assert.fieldEquals('Foundation', foundationId, 'shares', '25');
+  assert.fieldEquals('Foundation', foundationId, 'lockedUntil', '2');
+  assert.fieldEquals(
+    'Foundation',
+    foundationId,
+    'createdAt',
+    event.block.timestamp.toString(),
   );
-  event.parameters = new Array();
-
-  event.parameters.push(newI32('id', 1));
-  event.parameters.push(newI32('shares', 1));
-  event.parameters.push(newI32('amount', 1));
-  event.parameters.push(newAddress('to', MOCK_ADDRESS_1));
-  event.parameters.push(newBool('burned', true));
-
-  handleDepositWithdrawn(event);
-
-  assert.fieldEquals('Deposit', '1', 'burned', 'true');
-  assert.fieldEquals('Deposit', '1', 'shares', '0');
-  assert.fieldEquals('Deposit', '1', 'amount', '0');
-  assert.fieldEquals('Foundation', '1', 'amountDeposited', '0');
-});
-
-test('handleYieldClaimed reduces shares from Deposits and creates Donations', () => {
-  clearStore();
-
-  let mockEvent = newMockEvent();
-
-  // Create deposits
-  createDeposit('1', 50, false, '1', '1', 1, 50);
-  createDeposit('2', 100, false, '1', '1', 1, 100);
-
-  // Create vault
-  const vault = new Vault(mockEvent.address.toHexString());
-  vault.treasury = Address.fromString(TREASURY_ADDRESS);
-  vault.save();
-
-  // Create claimer
-  const claimer = new Claimer(MOCK_ADDRESS_1);
-  claimer.vault = mockEvent.address.toHexString();
-  claimer.depositsIds = ['1', '2'];
-  claimer.save();
-
-  // Create foundation
-  const foundation = new Foundation('1');
-  foundation.vault = mockEvent.address.toHexString();
-  foundation.save();
-
-  const event = new YieldClaimed(
-    mockEvent.address,
-    mockEvent.logIndex,
-    mockEvent.transactionLogIndex,
-    mockEvent.logType,
-    mockEvent.block,
-    mockEvent.transaction,
-    mockEvent.parameters,
-  );
-  event.parameters = new Array();
-
-  event.parameters.push(newAddress('claimerId', MOCK_ADDRESS_1));
-  event.parameters.push(newAddress('to', TREASURY_ADDRESS));
-  event.parameters.push(newI32('amount', 150));
-  event.parameters.push(newI32('burnedShares', 75));
-  event.parameters.push(newI32('perfFee', 0));
-
-  handleYieldClaimed(event);
-
-  assert.fieldEquals('Deposit', '1', 'shares', '25');
-  assert.fieldEquals('Deposit', '2', 'shares', '50');
-
-  assert.fieldEquals('Donation', donationId(mockEvent, '0'), 'amount', '50');
-  assert.fieldEquals('Donation', donationId(mockEvent, '1'), 'amount', '100');
-
-  clearStore();
-});
-
-test('handleYieldClaimed takes the performance fee into account', () => {
-  clearStore();
-
-  let mockEvent = newMockEvent();
-
-  // Create deposits
-  createDeposit('1', 50, false, '1', '1', 1, 50);
-  createDeposit('2', 100, false, '1', '1', 1, 100);
-
-  // Create vault
-  const vault = new Vault(mockEvent.address.toHexString());
-  vault.treasury = Address.fromString(TREASURY_ADDRESS);
-  vault.save();
-
-  // Create claimer
-  const claimer = new Claimer(MOCK_ADDRESS_1);
-  claimer.vault = mockEvent.address.toHexString();
-  claimer.depositsIds = ['1', '2'];
-  claimer.save();
-
-  // Create foundation
-  const foundation = new Foundation('1');
-  foundation.vault = mockEvent.address.toHexString();
-  foundation.save();
-
-  const event = new YieldClaimed(
-    mockEvent.address,
-    mockEvent.logIndex,
-    mockEvent.transactionLogIndex,
-    mockEvent.logType,
-    mockEvent.block,
-    mockEvent.transaction,
-    mockEvent.parameters,
-  );
-  event.parameters = new Array();
-
-  event.parameters.push(newAddress('claimerId', MOCK_ADDRESS_1));
-  event.parameters.push(newAddress('to', TREASURY_ADDRESS));
-  event.parameters.push(newI32('amount', 120));
-  event.parameters.push(newI32('burnedShares', 75));
-  event.parameters.push(newI32('perfFee', 30));
-
-  handleYieldClaimed(event);
-
-  assert.fieldEquals('Claimer', MOCK_ADDRESS_1, 'claimed', '120');
-
-  assert.fieldEquals('Deposit', '1', 'shares', '25');
-  assert.fieldEquals('Deposit', '2', 'shares', '50');
-
-  assert.fieldEquals('Donation', donationId(mockEvent, '0'), 'amount', '40');
-  assert.fieldEquals('Donation', donationId(mockEvent, '1'), 'amount', '80');
-
-  clearStore();
-});
-
-test("handleYieldClaimed doesn't create donations if the deposits are not to the treasury", () => {
-  clearStore();
-
-  let mockEvent = newMockEvent();
-
-  // Create deposits
-  createDeposit('1', 50, false, '1', '1', 1, 50);
-  createDeposit('2', 100, false, '1', '1', 1, 100);
-
-  // Create vault
-  const vault = new Vault(mockEvent.address.toHexString());
-  vault.treasury = Address.fromString(TREASURY_ADDRESS);
-  vault.save();
-
-  // Create claimer
-  const claimer = new Claimer(MOCK_ADDRESS_2);
-  claimer.vault = mockEvent.address.toHexString();
-  claimer.depositsIds = ['1', '2'];
-  claimer.save();
-
-  // Create foundation
-  const foundation = new Foundation('1');
-  foundation.vault = mockEvent.address.toHexString();
-  foundation.save();
-
-  const event = new YieldClaimed(
-    mockEvent.address,
-    mockEvent.logIndex,
-    mockEvent.transactionLogIndex,
-    mockEvent.logType,
-    mockEvent.block,
-    mockEvent.transaction,
-    mockEvent.parameters,
-  );
-  event.parameters = new Array();
-
-  event.parameters.push(newAddress('claimerId', MOCK_ADDRESS_2));
-  event.parameters.push(newAddress('to', MOCK_ADDRESS_1));
-  event.parameters.push(newI32('amount', 150));
-  event.parameters.push(newI32('burnedShares', 75));
-  event.parameters.push(newI32('perfFee', 0));
-
-  handleYieldClaimed(event);
-
-  assert.notInStore('Donation', donationId(mockEvent, '0'));
-  assert.notInStore('Donation', donationId(mockEvent, '1'));
-
-  clearStore();
 });
 
 test('handleYieldClaimed handles scenarios where only one of the deposits generated yield', () => {
@@ -910,51 +260,3 @@ test('handleYieldClaimed handles scenarios where the yield is not proportional t
   assert.fieldEquals('Donation', donationId(mockEvent, '0'), 'amount', '99');
   assert.fieldEquals('Donation', donationId(mockEvent, '1'), 'amount', '48');
 });
-
-function newBytes(name: string, value: Bytes): ethereum.EventParam {
-  return new ethereum.EventParam(name, ethereum.Value.fromBytes(value));
-}
-
-function newI32(name: string, value: i32): ethereum.EventParam {
-  return new ethereum.EventParam(name, ethereum.Value.fromI32(value));
-}
-
-function newBool(name: string, value: bool): ethereum.EventParam {
-  return new ethereum.EventParam(name, ethereum.Value.fromBoolean(value));
-}
-
-function newAddress(name: string, value: string): ethereum.EventParam {
-  return new ethereum.EventParam(
-    name,
-    ethereum.Value.fromAddress(Address.fromString(value)),
-  );
-}
-
-function newString(name: string, value: string): ethereum.EventParam {
-  return new ethereum.EventParam(name, ethereum.Value.fromString(value));
-}
-
-function donationId(event: ethereum.Event, id: string): string {
-  return (
-    event.transaction.hash.toHex() + '-' + event.logIndex.toString() + '-' + id
-  );
-}
-
-function createDeposit(
-  id: string,
-  amount: i32,
-  burned: bool,
-  claimer: string,
-  foundation: string,
-  lockedUntil: i32,
-  shares: i32,
-): void {
-  const deposit = new Deposit(id);
-  deposit.amount = BigInt.fromI32(amount);
-  deposit.burned = burned;
-  deposit.claimer = claimer;
-  deposit.foundation = foundation;
-  deposit.lockedUntil = BigInt.fromI32(lockedUntil);
-  deposit.shares = BigInt.fromI32(shares);
-  deposit.save();
-}

--- a/subgraph/tests/integration.test.ts
+++ b/subgraph/tests/integration.test.ts
@@ -9,6 +9,7 @@ import {
 import {
   newBytes,
   newI32,
+  newI32FromBigInt,
   newBool,
   newAddress,
   newString,
@@ -33,6 +34,134 @@ import { Vault, Claimer, Foundation } from '../src/types/schema';
 const MOCK_ADDRESS_1 = '0xC80B3caAd6d2DE80Ac76a41d5F0072E36D2519Cd'.toLowerCase();
 const MOCK_ADDRESS_2 = '0xE80B3caAd6d2DE80Ac76a41d5F0072E36D2519Ce'.toLowerCase();
 const TREASURY_ADDRESS = '0x4940c6e628da11ac0bdcf7f82be8579b4696fa33';
+
+test('handles scenarios with rounding matters', () => {
+  clearStore();
+
+  // Deposit 1
+
+  let mockEvent = newMockEvent();
+  const event = new DepositMinted(
+    mockEvent.address,
+    mockEvent.logIndex,
+    mockEvent.transactionLogIndex,
+    mockEvent.logType,
+    mockEvent.block,
+    mockEvent.transaction,
+    mockEvent.parameters,
+  );
+  event.parameters = new Array();
+
+  const vault = new Vault(mockEvent.address.toHexString());
+  vault.save();
+
+  let idParam = newI32('id', 1);
+  const groupId = newI32('groupId', 1);
+  let amount = newI32FromBigInt('amount', '500000000000000000000');
+  let shares = newI32FromBigInt(
+    'shares',
+    '500000000000000000000000000000000000000',
+  );
+  let depositor = newAddress('depositor', MOCK_ADDRESS_1);
+  let claimer = newAddress('claimer', MOCK_ADDRESS_1);
+  let lockedUntil = newI32('lockedUntil', 1);
+  let data = newBytes('data', Bytes.empty());
+  let name = newString('name', 'Foundation');
+
+  event.parameters.push(idParam);
+  event.parameters.push(groupId);
+  event.parameters.push(amount);
+  event.parameters.push(shares);
+  event.parameters.push(depositor);
+  event.parameters.push(claimer);
+  event.parameters.push(claimer);
+  event.parameters.push(lockedUntil);
+  event.parameters.push(data);
+  event.parameters.push(name);
+
+  handleDepositMinted(event);
+
+  const foundationId = `${vault.id}-1`;
+
+  // Deposit 2
+
+  mockEvent = newMockEvent();
+  const event2 = new DepositMinted(
+    mockEvent.address,
+    mockEvent.logIndex,
+    mockEvent.transactionLogIndex,
+    mockEvent.logType,
+    mockEvent.block,
+    mockEvent.transaction,
+    mockEvent.parameters,
+  );
+  event2.parameters = new Array();
+
+  idParam = newI32('id', 2);
+  depositor = newAddress('depositor', MOCK_ADDRESS_1);
+  claimer = newAddress('claimer', MOCK_ADDRESS_2);
+  lockedUntil = newI32('lockedUntil', 1);
+  data = newBytes('data', Bytes.empty());
+  name = newString('name', 'Foundation');
+
+  event2.parameters.push(idParam);
+  event2.parameters.push(groupId);
+  event2.parameters.push(amount);
+  event2.parameters.push(shares);
+  event2.parameters.push(depositor);
+  event2.parameters.push(claimer);
+  event2.parameters.push(claimer);
+  event2.parameters.push(lockedUntil);
+  event2.parameters.push(data);
+  event2.parameters.push(name);
+
+  handleDepositMinted(event2);
+
+  assert.fieldEquals('Foundation', foundationId, 'name', 'Foundation');
+  assert.fieldEquals(
+    'Foundation',
+    foundationId,
+    'amountDeposited',
+    '1000000000000000000000',
+  );
+  assert.fieldEquals(
+    'Foundation',
+    foundationId,
+    'shares',
+    '1000000000000000000000000000000000000000',
+  );
+  assert.fieldEquals('Foundation', foundationId, 'lockedUntil', '1');
+
+  // Claim Yield
+
+  mockEvent = newMockEvent();
+  const event3 = new YieldClaimed(
+    mockEvent.address,
+    mockEvent.logIndex,
+    mockEvent.transactionLogIndex,
+    mockEvent.logType,
+    mockEvent.block,
+    mockEvent.transaction,
+    mockEvent.parameters,
+  );
+  event3.parameters = new Array();
+
+  event3.parameters.push(newAddress('claimerId', MOCK_ADDRESS_1));
+  event3.parameters.push(newAddress('to', MOCK_ADDRESS_1));
+  event3.parameters.push(newI32FromBigInt('amount', '49500000000000000000'));
+  event3.parameters.push(
+    newI32FromBigInt('burnedShares', '45454545454545454545454545454545454545'),
+  );
+  event3.parameters.push(newI32FromBigInt('perfFee', '499999999999999999'));
+  event3.parameters.push(
+    newI32FromBigInt('totalUnderlying', '1100000000000000000000'),
+  );
+  event3.parameters.push(
+    newI32FromBigInt('totalShares', '1000000000000000000000000000000000000000'),
+  );
+
+  handleYieldClaimed(event3);
+});
 
 test('updates the Foundation', () => {
   clearStore();
@@ -105,8 +234,8 @@ test('updates the Foundation', () => {
   event2.parameters = new Array();
 
   idParam = newI32('id', 2);
-  amount = newI32('amount', 20);
-  shares = newI32('shares', 20);
+  amount = newI32('amount', 40);
+  shares = newI32('shares', 40);
   depositor = newAddress('depositor', MOCK_ADDRESS_1);
   claimer = newAddress('claimer', MOCK_ADDRESS_1);
   lockedUntil = newI32('lockedUntil', 2);
@@ -129,8 +258,8 @@ test('updates the Foundation', () => {
   assert.fieldEquals('Foundation', foundationId, 'name', 'Foundation 2');
   assert.fieldEquals('Foundation', foundationId, 'owner', MOCK_ADDRESS_1);
   assert.fieldEquals('Foundation', foundationId, 'vault', vault.id);
-  assert.fieldEquals('Foundation', foundationId, 'amountDeposited', '50');
-  assert.fieldEquals('Foundation', foundationId, 'shares', '50');
+  assert.fieldEquals('Foundation', foundationId, 'amountDeposited', '70');
+  assert.fieldEquals('Foundation', foundationId, 'shares', '70');
   assert.fieldEquals('Foundation', foundationId, 'lockedUntil', '2');
   assert.fieldEquals(
     'Foundation',
@@ -161,8 +290,9 @@ test('updates the Foundation', () => {
 
   handleDepositWithdrawn(event3);
 
-  assert.fieldEquals('Foundation', foundationId, 'amountDeposited', '40');
-  assert.fieldEquals('Foundation', foundationId, 'shares', '40');
+  assert.fieldEquals('Foundation', foundationId, 'amountDeposited', '60');
+  assert.fieldEquals('Foundation', foundationId, 'shares', '60');
+  assert.fieldEquals('Foundation', foundationId, 'amountClaimed', '0');
 
   // Claim yield
 
@@ -180,15 +310,17 @@ test('updates the Foundation', () => {
 
   event4.parameters.push(newAddress('claimerId', MOCK_ADDRESS_1));
   event4.parameters.push(newAddress('to', MOCK_ADDRESS_1));
-  event4.parameters.push(newI32('amount', 40));
-  event4.parameters.push(newI32('burnedShares', 20));
+  event4.parameters.push(newI32('amount', 60));
+  event4.parameters.push(newI32('burnedShares', 30));
   event4.parameters.push(newI32('perfFee', 0));
+  event4.parameters.push(newI32('totalUnderlying', 120));
+  event4.parameters.push(newI32('totalShares', 60));
 
   handleYieldClaimed(event4);
 
-  assert.fieldEquals('Foundation', foundationId, 'amountDeposited', '40');
-  assert.fieldEquals('Foundation', foundationId, 'shares', '20');
-  assert.fieldEquals('Foundation', foundationId, 'amountClaimed', '40');
+  assert.fieldEquals('Foundation', foundationId, 'amountDeposited', '60');
+  assert.fieldEquals('Foundation', foundationId, 'shares', '30');
+  assert.fieldEquals('Foundation', foundationId, 'amountClaimed', '60');
 });
 
 test('handleYieldClaimed handles scenarios where only one of the deposits generated yield', () => {
@@ -229,6 +361,8 @@ test('handleYieldClaimed handles scenarios where only one of the deposits genera
   event.parameters.push(newI32('amount', 50));
   event.parameters.push(newI32('burnedShares', 25));
   event.parameters.push(newI32('perfFee', 0));
+  event.parameters.push(newI32('totalUnderlying', 200));
+  event.parameters.push(newI32('totalShares', 100));
 
   handleYieldClaimed(event);
 
@@ -275,6 +409,11 @@ test('handleYieldClaimed handles scenarios where the yield is not proportional t
   event.parameters.push(newI32('amount', 147));
   event.parameters.push(newI32('burnedShares', 49));
   event.parameters.push(newI32('perfFee', 0));
+  // these numbers are only used to calculate the pricer per share
+  // in this scenario, it's impossible to find the real numbers, so'll just use these two
+  // because only the ratio between them matters for the purpose of this test
+  event.parameters.push(newI32('totalUnderlying', 147));
+  event.parameters.push(newI32('totalShares', 49));
 
   handleYieldClaimed(event);
 

--- a/subgraph/tests/integration.test.ts
+++ b/subgraph/tests/integration.test.ts
@@ -54,8 +54,8 @@ test('updates the Foundation', () => {
 
   let idParam = newI32('id', 1);
   const groupId = newI32('groupId', 1);
-  let amount = newI32('amount', 10);
-  let shares = newI32('shares', 10);
+  let amount = newI32('amount', 30);
+  let shares = newI32('shares', 30);
   let depositor = newAddress('depositor', MOCK_ADDRESS_1);
   let claimer = newAddress('claimer', MOCK_ADDRESS_1);
   let lockedUntil = newI32('lockedUntil', 1);
@@ -80,8 +80,8 @@ test('updates the Foundation', () => {
   assert.fieldEquals('Foundation', foundationId, 'name', 'Foundation');
   assert.fieldEquals('Foundation', foundationId, 'owner', MOCK_ADDRESS_1);
   assert.fieldEquals('Foundation', foundationId, 'vault', vault.id);
-  assert.fieldEquals('Foundation', foundationId, 'amountDeposited', '10');
-  assert.fieldEquals('Foundation', foundationId, 'shares', '10');
+  assert.fieldEquals('Foundation', foundationId, 'amountDeposited', '30');
+  assert.fieldEquals('Foundation', foundationId, 'shares', '30');
   assert.fieldEquals('Foundation', foundationId, 'lockedUntil', '1');
   assert.fieldEquals(
     'Foundation',
@@ -106,7 +106,7 @@ test('updates the Foundation', () => {
 
   idParam = newI32('id', 2);
   amount = newI32('amount', 20);
-  shares = newI32('shares', 15);
+  shares = newI32('shares', 20);
   depositor = newAddress('depositor', MOCK_ADDRESS_1);
   claimer = newAddress('claimer', MOCK_ADDRESS_1);
   lockedUntil = newI32('lockedUntil', 2);
@@ -129,8 +129,8 @@ test('updates the Foundation', () => {
   assert.fieldEquals('Foundation', foundationId, 'name', 'Foundation 2');
   assert.fieldEquals('Foundation', foundationId, 'owner', MOCK_ADDRESS_1);
   assert.fieldEquals('Foundation', foundationId, 'vault', vault.id);
-  assert.fieldEquals('Foundation', foundationId, 'amountDeposited', '30');
-  assert.fieldEquals('Foundation', foundationId, 'shares', '25');
+  assert.fieldEquals('Foundation', foundationId, 'amountDeposited', '50');
+  assert.fieldEquals('Foundation', foundationId, 'shares', '50');
   assert.fieldEquals('Foundation', foundationId, 'lockedUntil', '2');
   assert.fieldEquals(
     'Foundation',
@@ -154,15 +154,41 @@ test('updates the Foundation', () => {
   event3.parameters = new Array();
 
   event3.parameters.push(newI32('id', 1));
-  event3.parameters.push(newI32('shares', 5));
+  event3.parameters.push(newI32('shares', 10));
   event3.parameters.push(newI32('amount', 10));
   event3.parameters.push(newAddress('to', MOCK_ADDRESS_1));
   event3.parameters.push(newBool('burned', false));
 
   handleDepositWithdrawn(event3);
 
-  assert.fieldEquals('Foundation', foundationId, 'amountDeposited', '20');
+  assert.fieldEquals('Foundation', foundationId, 'amountDeposited', '40');
+  assert.fieldEquals('Foundation', foundationId, 'shares', '40');
+
+  // Claim yield
+
+  mockEvent = newMockEvent();
+  const event4 = new YieldClaimed(
+    mockEvent.address,
+    mockEvent.logIndex,
+    mockEvent.transactionLogIndex,
+    mockEvent.logType,
+    mockEvent.block,
+    mockEvent.transaction,
+    mockEvent.parameters,
+  );
+  event4.parameters = new Array();
+
+  event4.parameters.push(newAddress('claimerId', MOCK_ADDRESS_1));
+  event4.parameters.push(newAddress('to', MOCK_ADDRESS_1));
+  event4.parameters.push(newI32('amount', 40));
+  event4.parameters.push(newI32('burnedShares', 20));
+  event4.parameters.push(newI32('perfFee', 0));
+
+  handleYieldClaimed(event4);
+
+  assert.fieldEquals('Foundation', foundationId, 'amountDeposited', '40');
   assert.fieldEquals('Foundation', foundationId, 'shares', '20');
+  assert.fieldEquals('Foundation', foundationId, 'amountClaimed', '40');
 });
 
 test('handleYieldClaimed handles scenarios where only one of the deposits generated yield', () => {

--- a/subgraph/tests/unit.test.ts
+++ b/subgraph/tests/unit.test.ts
@@ -715,6 +715,8 @@ test('handleYieldClaimed reduces shares from Deposits and creates Donations', ()
   event.parameters.push(newI32('amount', 150));
   event.parameters.push(newI32('burnedShares', 75));
   event.parameters.push(newI32('perfFee', 0));
+  event.parameters.push(newI32('totalUnderlying', 300));
+  event.parameters.push(newI32('totalShares', 150));
 
   handleYieldClaimed(event);
 
@@ -768,6 +770,8 @@ test('handleYieldClaimed takes the performance fee into account', () => {
   event.parameters.push(newI32('amount', 120));
   event.parameters.push(newI32('burnedShares', 75));
   event.parameters.push(newI32('perfFee', 30));
+  event.parameters.push(newI32('totalUnderlying', 300));
+  event.parameters.push(newI32('totalShares', 150));
 
   handleYieldClaimed(event);
 
@@ -823,6 +827,8 @@ test("handleYieldClaimed doesn't create donations if the deposits are not to the
   event.parameters.push(newI32('amount', 150));
   event.parameters.push(newI32('burnedShares', 75));
   event.parameters.push(newI32('perfFee', 0));
+  event.parameters.push(newI32('totalUnderlying', 300));
+  event.parameters.push(newI32('totalShares', 150));
 
   handleYieldClaimed(event);
 

--- a/subgraph/tests/unit.test.ts
+++ b/subgraph/tests/unit.test.ts
@@ -1,0 +1,827 @@
+import { Address, Bytes, BigInt } from '@graphprotocol/graph-ts';
+import {
+  test,
+  assert,
+  newMockEvent,
+  clearStore,
+} from 'matchstick-as/assembly/index';
+
+import {
+  newBytes,
+  newI32,
+  newBool,
+  newAddress,
+  newString,
+  donationId,
+  createDeposit,
+} from './helpers';
+
+import {
+  handleDepositMinted,
+  handleSponsored,
+  handleUnsponsored,
+  handleDepositWithdrawn,
+  handleYieldClaimed,
+  handleTreasuryUpdated,
+} from '../src/mappings/vault';
+import {
+  handleInitDeposit,
+  handleInitRedeem,
+  handleFinishDeposit,
+  handleFinishRedeem,
+  handleRearrangeDeposit,
+  handleRearrangeRedeem,
+} from '../src/mappings/strategy';
+import { Sponsored, Unsponsored } from '../src/types/Vault/IVaultSponsoring';
+import {
+  DepositWithdrawn,
+  DepositMinted,
+  YieldClaimed,
+} from '../src/types/Vault/IVault';
+import { TreasuryUpdated } from '../src/types/Vault/IVaultSettings';
+import {
+  Vault,
+  Deposit,
+  Sponsor,
+  Claimer,
+  Foundation,
+  DepositOperation,
+  RedeemOperation,
+} from '../src/types/schema';
+import {
+  FinishDepositStable,
+  FinishRedeemStable,
+  InitDepositStable,
+  InitRedeemStable,
+  RearrangeDepositOperation,
+  RearrangeRedeemOperation,
+} from '../src/types/Strategy/AnchorStrategy';
+
+const MOCK_ADDRESS_1 = '0xC80B3caAd6d2DE80Ac76a41d5F0072E36D2519Cd'.toLowerCase();
+const MOCK_ADDRESS_2 = '0xE80B3caAd6d2DE80Ac76a41d5F0072E36D2519Ce'.toLowerCase();
+const TREASURY_ADDRESS = '0x4940c6e628da11ac0bdcf7f82be8579b4696fa33';
+
+test('handleInitDeposit creates a DepositOperation', () => {
+  clearStore();
+
+  let mockEvent = newMockEvent();
+  const event = new InitDepositStable(
+    mockEvent.address,
+    mockEvent.logIndex,
+    mockEvent.transactionLogIndex,
+    mockEvent.logType,
+    mockEvent.block,
+    mockEvent.transaction,
+    mockEvent.parameters,
+  );
+  event.parameters = new Array();
+
+  const operator = newAddress('operator', MOCK_ADDRESS_1);
+  const idx = newI32('idx', 1);
+  const underlyingAmount = newI32('underlyingAmount', 1);
+  const ustAmount = newI32('ustAmount', 1);
+
+  event.parameters.push(operator);
+  event.parameters.push(idx);
+  event.parameters.push(ustAmount);
+  event.parameters.push(underlyingAmount);
+
+  handleInitDeposit(event);
+
+  assert.fieldEquals('DepositOperation', MOCK_ADDRESS_1, 'idx', '1');
+  assert.fieldEquals(
+    'DepositOperation',
+    MOCK_ADDRESS_1,
+    'underlyingAmount',
+    '1',
+  );
+  assert.fieldEquals('DepositOperation', MOCK_ADDRESS_1, 'ustAmount', '1');
+});
+
+test('RearrangeDepositOperation updates the DepositOperation idx', () => {
+  clearStore();
+
+  let mockDepositEvent = newMockEvent();
+  const depositEvent = new InitDepositStable(
+    mockDepositEvent.address,
+    mockDepositEvent.logIndex,
+    mockDepositEvent.transactionLogIndex,
+    mockDepositEvent.logType,
+    mockDepositEvent.block,
+    mockDepositEvent.transaction,
+    mockDepositEvent.parameters,
+  );
+  depositEvent.parameters = new Array();
+
+  let operator = newAddress('operator', MOCK_ADDRESS_1);
+  let idx = newI32('idx', 1);
+  let underlyingAmount = newI32('underlyingAmount', 1);
+  let ustAmount = newI32('ustAmount', 1);
+
+  depositEvent.parameters.push(operator);
+  depositEvent.parameters.push(idx);
+  depositEvent.parameters.push(ustAmount);
+  depositEvent.parameters.push(underlyingAmount);
+
+  handleInitDeposit(depositEvent);
+
+  let mockDepositEvent1 = newMockEvent();
+  const depositEvent1 = new InitDepositStable(
+    mockDepositEvent1.address,
+    mockDepositEvent1.logIndex,
+    mockDepositEvent1.transactionLogIndex,
+    mockDepositEvent1.logType,
+    mockDepositEvent1.block,
+    mockDepositEvent1.transaction,
+    mockDepositEvent1.parameters,
+  );
+  depositEvent1.parameters = new Array();
+
+  operator = newAddress('operator', MOCK_ADDRESS_2);
+  idx = newI32('idx', 2);
+
+  depositEvent1.parameters.push(operator);
+  depositEvent1.parameters.push(idx);
+  depositEvent1.parameters.push(ustAmount);
+  depositEvent1.parameters.push(underlyingAmount);
+
+  handleInitDeposit(depositEvent1);
+
+  let mockEvent = newMockEvent();
+  const event = new RearrangeDepositOperation(
+    mockEvent.address,
+    mockEvent.logIndex,
+    mockEvent.transactionLogIndex,
+    mockEvent.logType,
+    mockEvent.block,
+    mockEvent.transaction,
+    mockEvent.parameters,
+  );
+  event.parameters = new Array();
+
+  const operatorFrom = newAddress('operatorFrom', MOCK_ADDRESS_2);
+  const operatorTo = newAddress('operatorTo', MOCK_ADDRESS_1);
+  idx = newI32('idx', 1);
+
+  event.parameters.push(operatorFrom);
+  event.parameters.push(operatorTo);
+  event.parameters.push(idx);
+
+  assert.fieldEquals('DepositOperation', MOCK_ADDRESS_2, 'idx', '2');
+  assert.fieldEquals('DepositOperation', MOCK_ADDRESS_1, 'idx', '1');
+
+  handleRearrangeDeposit(event);
+
+  assert.fieldEquals('DepositOperation', MOCK_ADDRESS_2, 'idx', '1');
+  assert.fieldEquals('DepositOperation', MOCK_ADDRESS_1, 'idx', '1');
+});
+
+test('handleFinishDeposit deletes the DepositOperation', () => {
+  clearStore();
+
+  const depositOperation = new DepositOperation(MOCK_ADDRESS_1);
+  depositOperation.save();
+
+  let mockEvent = newMockEvent();
+  const event = new FinishDepositStable(
+    mockEvent.address,
+    mockEvent.logIndex,
+    mockEvent.transactionLogIndex,
+    mockEvent.logType,
+    mockEvent.block,
+    mockEvent.transaction,
+    mockEvent.parameters,
+  );
+  event.parameters = new Array();
+
+  const operator = newAddress('operator', MOCK_ADDRESS_1);
+
+  event.parameters.push(operator);
+
+  handleFinishDeposit(event);
+
+  assert.notInStore('DepositOperation', MOCK_ADDRESS_1);
+});
+
+test('handleInitRedeem creates a RedeemOperation', () => {
+  clearStore();
+
+  let mockEvent = newMockEvent();
+  const event = new InitRedeemStable(
+    mockEvent.address,
+    mockEvent.logIndex,
+    mockEvent.transactionLogIndex,
+    mockEvent.logType,
+    mockEvent.block,
+    mockEvent.transaction,
+    mockEvent.parameters,
+  );
+  event.parameters = new Array();
+
+  const operator = newAddress('operator', MOCK_ADDRESS_1);
+  const idx = newI32('idx', 1);
+  const aUstAmount = newI32('aUstAmount', 1);
+
+  event.parameters.push(operator);
+  event.parameters.push(idx);
+  event.parameters.push(aUstAmount);
+
+  handleInitRedeem(event);
+
+  assert.fieldEquals('RedeemOperation', MOCK_ADDRESS_1, 'aUstAmount', '1');
+});
+
+test('RearrangeRedeemOperation updates the RedeemOperation idx', () => {
+  clearStore();
+
+  let mockRedeemEvent = newMockEvent();
+  const redeemEvent = new InitRedeemStable(
+    mockRedeemEvent.address,
+    mockRedeemEvent.logIndex,
+    mockRedeemEvent.transactionLogIndex,
+    mockRedeemEvent.logType,
+    mockRedeemEvent.block,
+    mockRedeemEvent.transaction,
+    mockRedeemEvent.parameters,
+  );
+  redeemEvent.parameters = new Array();
+
+  let operator = newAddress('operator', MOCK_ADDRESS_1);
+  let aUstAmount = newI32('aUstAmount', 1);
+  let idx = newI32('idx', 1);
+
+  redeemEvent.parameters.push(operator);
+  redeemEvent.parameters.push(idx);
+  redeemEvent.parameters.push(aUstAmount);
+
+  handleInitRedeem(redeemEvent);
+
+  let mockRedeemEvent1 = newMockEvent();
+  const redeemEvent1 = new InitRedeemStable(
+    mockRedeemEvent1.address,
+    mockRedeemEvent1.logIndex,
+    mockRedeemEvent1.transactionLogIndex,
+    mockRedeemEvent1.logType,
+    mockRedeemEvent1.block,
+    mockRedeemEvent1.transaction,
+    mockRedeemEvent1.parameters,
+  );
+  redeemEvent1.parameters = new Array();
+
+  operator = newAddress('operator', MOCK_ADDRESS_2);
+  idx = newI32('idx', 2);
+
+  redeemEvent1.parameters.push(operator);
+  redeemEvent1.parameters.push(idx);
+  redeemEvent1.parameters.push(aUstAmount);
+
+  handleInitRedeem(redeemEvent1);
+
+  const mockEvent = newMockEvent();
+  const event = new RearrangeRedeemOperation(
+    mockEvent.address,
+    mockEvent.logIndex,
+    mockEvent.transactionLogIndex,
+    mockEvent.logType,
+    mockEvent.block,
+    mockEvent.transaction,
+    mockEvent.parameters,
+  );
+  event.parameters = new Array();
+
+  const operatorFrom = newAddress('operatorFrom', MOCK_ADDRESS_2);
+  const operatorTo = newAddress('operatorTo', MOCK_ADDRESS_1);
+  idx = newI32('idx', 1);
+
+  event.parameters.push(operatorFrom);
+  event.parameters.push(operatorTo);
+  event.parameters.push(idx);
+
+  assert.fieldEquals('RedeemOperation', MOCK_ADDRESS_2, 'idx', '2');
+  assert.fieldEquals('RedeemOperation', MOCK_ADDRESS_1, 'idx', '1');
+
+  handleRearrangeRedeem(event);
+
+  assert.fieldEquals('RedeemOperation', MOCK_ADDRESS_2, 'idx', '1');
+  assert.fieldEquals('RedeemOperation', MOCK_ADDRESS_1, 'idx', '1');
+});
+
+test('handleFinishRedeem updates the RedeemOperation', () => {
+  clearStore();
+
+  const depositOperation = new RedeemOperation(MOCK_ADDRESS_1);
+  depositOperation.save();
+
+  let mockEvent = newMockEvent();
+  const event = new FinishRedeemStable(
+    mockEvent.address,
+    mockEvent.logIndex,
+    mockEvent.transactionLogIndex,
+    mockEvent.logType,
+    mockEvent.block,
+    mockEvent.transaction,
+    mockEvent.parameters,
+  );
+  event.parameters = new Array();
+
+  const operator = newAddress('operator', MOCK_ADDRESS_1);
+
+  event.parameters.push(operator);
+
+  handleFinishRedeem(event);
+
+  assert.notInStore('RedeemOperation', MOCK_ADDRESS_1);
+});
+
+test('handleTreasuryUpdated updates the treasury', () => {
+  clearStore();
+
+  let mockEvent = newMockEvent();
+  const event = new TreasuryUpdated(
+    mockEvent.address,
+    mockEvent.logIndex,
+    mockEvent.transactionLogIndex,
+    mockEvent.logType,
+    mockEvent.block,
+    mockEvent.transaction,
+    mockEvent.parameters,
+  );
+  event.parameters = new Array();
+
+  const treasury = newAddress('treasury', MOCK_ADDRESS_1);
+  event.parameters.push(treasury);
+
+  // create vault
+  const vault = new Vault(mockEvent.address.toHexString());
+  vault.save();
+
+  handleTreasuryUpdated(event);
+
+  assert.fieldEquals(
+    'Vault',
+    mockEvent.address.toHexString(),
+    'treasury',
+    MOCK_ADDRESS_1,
+  );
+});
+
+test('handleSponsored creates a Sponsor', () => {
+  clearStore();
+
+  let mockEvent = newMockEvent();
+  const event = new Sponsored(
+    mockEvent.address,
+    mockEvent.logIndex,
+    mockEvent.transactionLogIndex,
+    mockEvent.logType,
+    mockEvent.block,
+    mockEvent.transaction,
+    mockEvent.parameters,
+  );
+  event.parameters = new Array();
+
+  const idParam = newI32('id', 1);
+  const amount = newI32('amount', 1);
+  const depositor = newAddress('depositor', MOCK_ADDRESS_1);
+  const lockedUntil = newI32('lockedUntil', 1);
+  const burned = newBool('burned', false);
+
+  event.parameters.push(idParam);
+  event.parameters.push(amount);
+  event.parameters.push(depositor);
+  event.parameters.push(lockedUntil);
+  event.parameters.push(burned);
+
+  handleSponsored(event);
+
+  assert.fieldEquals('Sponsor', '1', 'amount', '1');
+  assert.fieldEquals('Sponsor', '1', 'depositor', MOCK_ADDRESS_1);
+  assert.fieldEquals('Sponsor', '1', 'burned', 'false');
+});
+
+test('handleUnsponsored removes a Sponsor by marking as burned', () => {
+  clearStore();
+
+  const sponsor = new Sponsor('1');
+  sponsor.burned = false;
+  sponsor.save();
+
+  let mockEvent = newMockEvent();
+  const event = new Unsponsored(
+    mockEvent.address,
+    mockEvent.logIndex,
+    mockEvent.transactionLogIndex,
+    mockEvent.logType,
+    mockEvent.block,
+    mockEvent.transaction,
+    mockEvent.parameters,
+  );
+  event.parameters = new Array();
+
+  const idParam = newI32('id', 1);
+
+  event.parameters.push(idParam);
+
+  handleUnsponsored(event);
+
+  assert.fieldEquals('Sponsor', '1', 'burned', 'true');
+});
+
+test('handleDepositMinted creates a Deposit', () => {
+  clearStore();
+
+  let mockEvent = newMockEvent();
+  const event = new DepositMinted(
+    mockEvent.address,
+    mockEvent.logIndex,
+    mockEvent.transactionLogIndex,
+    mockEvent.logType,
+    mockEvent.block,
+    mockEvent.transaction,
+    mockEvent.parameters,
+  );
+  event.parameters = new Array();
+
+  const vault = new Vault(mockEvent.address.toHexString());
+  vault.save();
+
+  const idParam = newI32('id', 1);
+  const groupId = newI32('groupId', 1);
+  const amount = newI32('amount', 1);
+  const shares = newI32('shares', 1);
+  const depositor = newAddress('depositor', MOCK_ADDRESS_1);
+  const claimer = newAddress('claimer', MOCK_ADDRESS_1);
+  const lockedUntil = newI32('lockedUntil', 1);
+  const data = newBytes('data', Bytes.empty());
+  const name = newString('name', 'Foundation');
+
+  event.parameters.push(idParam);
+  event.parameters.push(groupId);
+  event.parameters.push(amount);
+  event.parameters.push(shares);
+  event.parameters.push(depositor);
+  event.parameters.push(claimer);
+  event.parameters.push(claimer);
+  event.parameters.push(lockedUntil);
+  event.parameters.push(data);
+  event.parameters.push(name);
+
+  handleDepositMinted(event);
+
+  assert.fieldEquals('Deposit', '1', 'amount', '1');
+  assert.fieldEquals('Deposit', '1', 'depositor', MOCK_ADDRESS_1);
+  assert.fieldEquals('Deposit', '1', 'claimer', MOCK_ADDRESS_1);
+  assert.fieldEquals('Claimer', MOCK_ADDRESS_1, 'principal', '1');
+  assert.fieldEquals('Claimer', MOCK_ADDRESS_1, 'depositsIds', '[1]');
+
+  const foundationId = `${vault.id}-1`;
+  assert.fieldEquals('Foundation', foundationId, 'name', 'Foundation');
+  assert.fieldEquals('Foundation', foundationId, 'owner', MOCK_ADDRESS_1);
+  assert.fieldEquals('Foundation', foundationId, 'vault', vault.id);
+  assert.fieldEquals('Foundation', foundationId, 'amountDeposited', '1');
+  assert.fieldEquals('Foundation', foundationId, 'lockedUntil', '1');
+  assert.fieldEquals(
+    'Foundation',
+    foundationId,
+    'createdAt',
+    event.block.timestamp.toString(),
+  );
+});
+
+test("handleDepositMinted uses the last event's name as the Foundation's name", () => {
+  clearStore();
+
+  let mockEvent = newMockEvent();
+  let event = new DepositMinted(
+    mockEvent.address,
+    mockEvent.logIndex,
+    mockEvent.transactionLogIndex,
+    mockEvent.logType,
+    mockEvent.block,
+    mockEvent.transaction,
+    mockEvent.parameters,
+  );
+  event.parameters = new Array();
+
+  const vault = new Vault(mockEvent.address.toHexString());
+  vault.save();
+
+  const idParam = newI32('id', 1);
+  const groupId = newI32('groupId', 1);
+  const amount = newI32('amount', 1);
+  const shares = newI32('shares', 1);
+  const depositor = newAddress('depositor', MOCK_ADDRESS_1);
+  const claimer = newAddress('claimer', MOCK_ADDRESS_1);
+  const claimerId = newAddress('claimerId', MOCK_ADDRESS_1);
+  const lockedUntil = newI32('lockedUntil', 1);
+  const data = newBytes('data', Bytes.empty());
+  let name = newString('name', 'Foundation');
+
+  event.parameters.push(idParam);
+  event.parameters.push(groupId);
+  event.parameters.push(amount);
+  event.parameters.push(shares);
+  event.parameters.push(depositor);
+  event.parameters.push(claimer);
+  event.parameters.push(claimerId);
+  event.parameters.push(lockedUntil);
+  event.parameters.push(data);
+  event.parameters.push(name);
+
+  handleDepositMinted(event);
+
+  const foundationId = `${mockEvent.address.toHexString()}-1`;
+  assert.fieldEquals('Foundation', foundationId, 'name', 'Foundation');
+
+  // Sending another DepositMinted that updates the name
+
+  mockEvent = newMockEvent();
+  event = new DepositMinted(
+    mockEvent.address,
+    mockEvent.logIndex,
+    mockEvent.transactionLogIndex,
+    mockEvent.logType,
+    mockEvent.block,
+    mockEvent.transaction,
+    mockEvent.parameters,
+  );
+  event.parameters = new Array();
+
+  name = newString('name', 'Updated Foundation Name');
+
+  event.parameters.push(idParam);
+  event.parameters.push(groupId);
+  event.parameters.push(amount);
+  event.parameters.push(shares);
+  event.parameters.push(depositor);
+  event.parameters.push(claimer);
+  event.parameters.push(claimerId);
+  event.parameters.push(lockedUntil);
+  event.parameters.push(data);
+  event.parameters.push(name);
+
+  handleDepositMinted(event);
+
+  assert.fieldEquals(
+    'Foundation',
+    foundationId,
+    'name',
+    'Updated Foundation Name',
+  );
+});
+
+test("handleDepositWithdrawn doesn't remove a Deposit for partial withdraws", () => {
+  clearStore();
+
+  let mockEvent = newMockEvent();
+
+  const claimer = new Claimer('1');
+  claimer.save();
+
+  const deposit = new Deposit('1');
+  deposit.burned = false;
+  deposit.amount = BigInt.fromI32(10);
+  deposit.lockedUntil = BigInt.fromI32(1);
+  deposit.shares = BigInt.fromI32(10);
+  deposit.claimer = '1';
+  deposit.foundation = '1';
+  deposit.save();
+
+  const vault = new Vault(mockEvent.address.toHexString());
+  vault.save();
+
+  const foundation = new Foundation('1');
+  foundation.vault = mockEvent.address.toHexString();
+  foundation.save();
+
+  const event = new DepositWithdrawn(
+    mockEvent.address,
+    mockEvent.logIndex,
+    mockEvent.transactionLogIndex,
+    mockEvent.logType,
+    mockEvent.block,
+    mockEvent.transaction,
+    mockEvent.parameters,
+  );
+  event.parameters = new Array();
+
+  event.parameters.push(newI32('id', 1));
+  event.parameters.push(newI32('shares', 5));
+  event.parameters.push(newI32('amount', 5));
+  event.parameters.push(newAddress('to', MOCK_ADDRESS_1));
+  event.parameters.push(newBool('burned', false));
+
+  handleDepositWithdrawn(event);
+
+  assert.fieldEquals('Deposit', '1', 'burned', 'false');
+  assert.fieldEquals('Deposit', '1', 'shares', '5');
+  assert.fieldEquals('Deposit', '1', 'amount', '5');
+  assert.fieldEquals('Foundation', '1', 'amountDeposited', '0');
+});
+
+test('handleDepositWithdrawn removes a Deposit by marking as burned', () => {
+  clearStore();
+
+  let mockEvent = newMockEvent();
+
+  const claimer = new Claimer('1');
+  claimer.save();
+
+  const deposit = new Deposit('1');
+  deposit.burned = false;
+  deposit.amount = BigInt.fromI32(1);
+  deposit.lockedUntil = BigInt.fromI32(1);
+  deposit.shares = BigInt.fromI32(1);
+  deposit.claimer = '1';
+  deposit.foundation = '1';
+  deposit.save();
+
+  const vault = new Vault(mockEvent.address.toHexString());
+  vault.save();
+
+  const foundation = new Foundation('1');
+  foundation.vault = mockEvent.address.toHexString();
+  foundation.save();
+
+  const event = new DepositWithdrawn(
+    mockEvent.address,
+    mockEvent.logIndex,
+    mockEvent.transactionLogIndex,
+    mockEvent.logType,
+    mockEvent.block,
+    mockEvent.transaction,
+    mockEvent.parameters,
+  );
+  event.parameters = new Array();
+
+  event.parameters.push(newI32('id', 1));
+  event.parameters.push(newI32('shares', 1));
+  event.parameters.push(newI32('amount', 1));
+  event.parameters.push(newAddress('to', MOCK_ADDRESS_1));
+  event.parameters.push(newBool('burned', true));
+
+  handleDepositWithdrawn(event);
+
+  assert.fieldEquals('Deposit', '1', 'burned', 'true');
+  assert.fieldEquals('Deposit', '1', 'shares', '0');
+  assert.fieldEquals('Deposit', '1', 'amount', '0');
+  assert.fieldEquals('Foundation', '1', 'amountDeposited', '0');
+});
+
+test('handleYieldClaimed reduces shares from Deposits and creates Donations', () => {
+  clearStore();
+
+  let mockEvent = newMockEvent();
+
+  // Create deposits
+  createDeposit('1', 50, false, '1', '1', 1, 50);
+  createDeposit('2', 100, false, '1', '1', 1, 100);
+
+  // Create vault
+  const vault = new Vault(mockEvent.address.toHexString());
+  vault.treasury = Address.fromString(TREASURY_ADDRESS);
+  vault.save();
+
+  // Create claimer
+  const claimer = new Claimer(MOCK_ADDRESS_1);
+  claimer.vault = mockEvent.address.toHexString();
+  claimer.depositsIds = ['1', '2'];
+  claimer.save();
+
+  // Create foundation
+  const foundation = new Foundation('1');
+  foundation.vault = mockEvent.address.toHexString();
+  foundation.save();
+
+  const event = new YieldClaimed(
+    mockEvent.address,
+    mockEvent.logIndex,
+    mockEvent.transactionLogIndex,
+    mockEvent.logType,
+    mockEvent.block,
+    mockEvent.transaction,
+    mockEvent.parameters,
+  );
+  event.parameters = new Array();
+
+  event.parameters.push(newAddress('claimerId', MOCK_ADDRESS_1));
+  event.parameters.push(newAddress('to', TREASURY_ADDRESS));
+  event.parameters.push(newI32('amount', 150));
+  event.parameters.push(newI32('burnedShares', 75));
+  event.parameters.push(newI32('perfFee', 0));
+
+  handleYieldClaimed(event);
+
+  assert.fieldEquals('Deposit', '1', 'shares', '25');
+  assert.fieldEquals('Deposit', '2', 'shares', '50');
+
+  assert.fieldEquals('Donation', donationId(mockEvent, '0'), 'amount', '50');
+  assert.fieldEquals('Donation', donationId(mockEvent, '1'), 'amount', '100');
+
+  clearStore();
+});
+
+test('handleYieldClaimed takes the performance fee into account', () => {
+  clearStore();
+
+  let mockEvent = newMockEvent();
+
+  // Create deposits
+  createDeposit('1', 50, false, '1', '1', 1, 50);
+  createDeposit('2', 100, false, '1', '1', 1, 100);
+
+  // Create vault
+  const vault = new Vault(mockEvent.address.toHexString());
+  vault.treasury = Address.fromString(TREASURY_ADDRESS);
+  vault.save();
+
+  // Create claimer
+  const claimer = new Claimer(MOCK_ADDRESS_1);
+  claimer.vault = mockEvent.address.toHexString();
+  claimer.depositsIds = ['1', '2'];
+  claimer.save();
+
+  // Create foundation
+  const foundation = new Foundation('1');
+  foundation.vault = mockEvent.address.toHexString();
+  foundation.save();
+
+  const event = new YieldClaimed(
+    mockEvent.address,
+    mockEvent.logIndex,
+    mockEvent.transactionLogIndex,
+    mockEvent.logType,
+    mockEvent.block,
+    mockEvent.transaction,
+    mockEvent.parameters,
+  );
+  event.parameters = new Array();
+
+  event.parameters.push(newAddress('claimerId', MOCK_ADDRESS_1));
+  event.parameters.push(newAddress('to', TREASURY_ADDRESS));
+  event.parameters.push(newI32('amount', 120));
+  event.parameters.push(newI32('burnedShares', 75));
+  event.parameters.push(newI32('perfFee', 30));
+
+  handleYieldClaimed(event);
+
+  assert.fieldEquals('Claimer', MOCK_ADDRESS_1, 'claimed', '120');
+
+  assert.fieldEquals('Deposit', '1', 'shares', '25');
+  assert.fieldEquals('Deposit', '2', 'shares', '50');
+
+  assert.fieldEquals('Donation', donationId(mockEvent, '0'), 'amount', '40');
+  assert.fieldEquals('Donation', donationId(mockEvent, '1'), 'amount', '80');
+
+  clearStore();
+});
+
+test("handleYieldClaimed doesn't create donations if the deposits are not to the treasury", () => {
+  clearStore();
+
+  let mockEvent = newMockEvent();
+
+  // Create deposits
+  createDeposit('1', 50, false, '1', '1', 1, 50);
+  createDeposit('2', 100, false, '1', '1', 1, 100);
+
+  // Create vault
+  const vault = new Vault(mockEvent.address.toHexString());
+  vault.treasury = Address.fromString(TREASURY_ADDRESS);
+  vault.save();
+
+  // Create claimer
+  const claimer = new Claimer(MOCK_ADDRESS_2);
+  claimer.vault = mockEvent.address.toHexString();
+  claimer.depositsIds = ['1', '2'];
+  claimer.save();
+
+  // Create foundation
+  const foundation = new Foundation('1');
+  foundation.vault = mockEvent.address.toHexString();
+  foundation.save();
+
+  const event = new YieldClaimed(
+    mockEvent.address,
+    mockEvent.logIndex,
+    mockEvent.transactionLogIndex,
+    mockEvent.logType,
+    mockEvent.block,
+    mockEvent.transaction,
+    mockEvent.parameters,
+  );
+  event.parameters = new Array();
+
+  event.parameters.push(newAddress('claimerId', MOCK_ADDRESS_2));
+  event.parameters.push(newAddress('to', MOCK_ADDRESS_1));
+  event.parameters.push(newI32('amount', 150));
+  event.parameters.push(newI32('burnedShares', 75));
+  event.parameters.push(newI32('perfFee', 0));
+
+  handleYieldClaimed(event);
+
+  assert.notInStore('Donation', donationId(mockEvent, '0'));
+  assert.notInStore('Donation', donationId(mockEvent, '1'));
+
+  clearStore();
+});

--- a/subgraph/tests/unit.test.ts
+++ b/subgraph/tests/unit.test.ts
@@ -592,6 +592,8 @@ test("handleDepositWithdrawn doesn't remove a Deposit for partial withdraws", ()
 
   const foundation = new Foundation('1');
   foundation.vault = mockEvent.address.toHexString();
+  foundation.amountDeposited = BigInt.fromI32(10);
+  foundation.shares = BigInt.fromI32(10);
   foundation.save();
 
   const event = new DepositWithdrawn(
@@ -616,7 +618,8 @@ test("handleDepositWithdrawn doesn't remove a Deposit for partial withdraws", ()
   assert.fieldEquals('Deposit', '1', 'burned', 'false');
   assert.fieldEquals('Deposit', '1', 'shares', '5');
   assert.fieldEquals('Deposit', '1', 'amount', '5');
-  assert.fieldEquals('Foundation', '1', 'amountDeposited', '0');
+  assert.fieldEquals('Foundation', '1', 'amountDeposited', '5');
+  assert.fieldEquals('Foundation', '1', 'shares', '5');
 });
 
 test('handleDepositWithdrawn removes a Deposit by marking as burned', () => {
@@ -641,6 +644,8 @@ test('handleDepositWithdrawn removes a Deposit by marking as burned', () => {
 
   const foundation = new Foundation('1');
   foundation.vault = mockEvent.address.toHexString();
+  foundation.amountDeposited = BigInt.fromI32(1);
+  foundation.shares = BigInt.fromI32(1);
   foundation.save();
 
   const event = new DepositWithdrawn(
@@ -666,6 +671,7 @@ test('handleDepositWithdrawn removes a Deposit by marking as burned', () => {
   assert.fieldEquals('Deposit', '1', 'shares', '0');
   assert.fieldEquals('Deposit', '1', 'amount', '0');
   assert.fieldEquals('Foundation', '1', 'amountDeposited', '0');
+  assert.fieldEquals('Foundation', '1', 'shares', '0');
 });
 
 test('handleYieldClaimed reduces shares from Deposits and creates Donations', () => {

--- a/subgraph/yarn.lock
+++ b/subgraph/yarn.lock
@@ -52,10 +52,17 @@
     which "2.0.2"
     yaml "^1.5.1"
 
-"@graphprotocol/graph-ts@0.24.1", "@graphprotocol/graph-ts@^0.24.1":
+"@graphprotocol/graph-ts@0.24.1":
   version "0.24.1"
   resolved "https://registry.yarnpkg.com/@graphprotocol/graph-ts/-/graph-ts-0.24.1.tgz#50961b52b5383f9c5cf5e6e23fa039f24e729ddf"
   integrity sha512-2vU4m5ZPQIqMlMce/z5vmOtGHRlRmcRhMfemS3NIwxCSxSBGVnX2zb7QBTzzdQKGwsAZdbz6V0okkOtvohELfQ==
+  dependencies:
+    assemblyscript "0.19.10"
+
+"@graphprotocol/graph-ts@^0.26.0":
+  version "0.26.0"
+  resolved "https://registry.yarnpkg.com/@graphprotocol/graph-ts/-/graph-ts-0.26.0.tgz#576f995531eebaca4374901aeaff499219e382e8"
+  integrity sha512-GW/emOJl+35MXgmIxTnUK7dJtPCaB9u5aAwoLVqJ8swogC794O92UrXMVrAJsherUriu+yI9bLMGmNPOIi60jw==
   dependencies:
     assemblyscript "0.19.10"
 
@@ -1814,12 +1821,12 @@ mafmt@^7.0.0:
   dependencies:
     multiaddr "^7.3.0"
 
-matchstick-as@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/matchstick-as/-/matchstick-as-0.3.0.tgz#fb23b9bf7c797363a40c23f098d3101831d088dc"
-  integrity sha512-+nxHlchVHzvcJzcNc8WxCV5FpADVqVJwEBuaq3IvZjp29xVoe/RWpodmTvQw+Pk6bRMAPI5grdmTPjR4hGgrcw==
+matchstick-as@^0.4.3:
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/matchstick-as/-/matchstick-as-0.4.3.tgz#c35aba5d4da2524d3546c25183b72ff8d0d210d3"
+  integrity sha512-0rDobz0L8ainmnBo5pPj0vPwRBdzZz8WfTLUCId/KXJyoaumrgrdicTcuj46QAguD0gOY4j8vWNonE1OR3EFzg==
   dependencies:
-    "@graphprotocol/graph-ts" "^0.24.1"
+    "@graphprotocol/graph-ts" "^0.26.0"
     assemblyscript "^0.19.20"
     wabt "1.0.24"
 

--- a/test/Vault.spec.ts
+++ b/test/Vault.spec.ts
@@ -1798,6 +1798,8 @@ describe('Vault', () => {
           parseUnits('49'),
           parseUnits('25').mul(SHARES_MULTIPLIER),
           parseUnits('1'),
+          parseUnits('200'),
+          parseUnits('100').mul(SHARES_MULTIPLIER),
         );
     });
 


### PR DESCRIPTION
In this change:
* add `shares` to the Foundation so we can know how much each Foundation is worth at any moment.
* add `amountClaimed` to the Foundation to know how much was claimed from a Foundation.
* fix mappings to handle partial withdrawals.
* refactor subgraph tests into two files, adding a third one for helper functions.
* write tests for the new functionality.
* added the `totalUnderlying` and `totalShares` to the `YieldClaimed` event. We need these two to calculate the correct price per share. The previous implementation had a bug because the ratio of `totalUnderlying / totalShares` can be different from `amount / burnedShares` when there's a loss of precision. The difference is slight, but it will mess up the number of shares on each deposit on the subgraph.