### PR TITLE
Add revert for invalid beneficiary 

### DIFF
--- a/contracts/Vault.sol
+++ b/contracts/Vault.sol
@@ -755,6 +755,7 @@ contract Vault is
         for (uint256 i; i < locals.claimsLen; ++i) {
             ClaimParams memory data = claims[i];
             if (data.pct == 0) revert VaultClaimPercentageCannotBe0();
+            if (data.beneficiary == address(0)) revert VaultNotDeposit();
             // if it's the last claim, just grab all remaining amount, instead
             // of relying on percentages
             uint256 localAmount = i == locals.claimsLen - 1

--- a/contracts/Vault.sol
+++ b/contracts/Vault.sol
@@ -699,13 +699,11 @@ contract Vault is
             emit Unsponsored(tokenId);
         }
 
-        uint256 sponsorToTransfer = sponsorAmount;
-
-        if (sponsorToTransfer > totalUnderlying()) revert VaultNotEnoughFunds();
+        if (sponsorAmount > totalUnderlying()) revert VaultNotEnoughFunds();
 
         totalSponsored -= sponsorAmount;
 
-        underlying.safeTransfer(_to, sponsorToTransfer);
+        underlying.safeTransfer(_to, sponsorAmount);
     }
 
     /**


### PR DESCRIPTION
- [ ] [L-5] deposit() with claimerId: address(0) may freeze the user's funds
- [ ] [N-0] sponsorToTransfer is unnecessary and misleading