### PR TITLE
Audit [H-7]

### DIFF
--- a/contracts/Vault.sol
+++ b/contracts/Vault.sol
@@ -19,8 +19,6 @@ import {PercentMath} from "./lib/PercentMath.sol";
 import {IStrategy} from "./strategy/IStrategy.sol";
 import {CustomErrors} from "./interfaces/CustomErrors.sol";
 
-import "hardhat/console.sol";
-
 /**
  * A vault where other accounts can deposit an underlying token
  * currency and set distribution params for their principal and yield

--- a/contracts/Vault.sol
+++ b/contracts/Vault.sol
@@ -163,7 +163,6 @@ contract Vault is
         perfFeePct = _perfFeePct;
         lossTolerancePct = _lossTolerancePct;
 
-
         rebalanceMinimum = 10 * 10**underlying.decimals();
 
         _addPools(_swapPools);
@@ -313,6 +312,9 @@ contract Vault is
         nonReentrant
     {
         if (_to == address(0)) revert VaultDestinationCannotBe0Address();
+
+        if (totalPrincipal > totalUnderlyingMinusSponsored())
+            revert VaultCannotWithdrawWhenYieldNegative();
 
         _withdrawAll(_to, _ids, false);
     }
@@ -895,8 +897,7 @@ contract Vault is
                 _totalUnderlyingMinusSponsored
             );
 
-        bool lostMoney = depositShares > _deposit.shares ||
-            depositShares > _claim.totalShares;
+        bool lostMoney = totalPrincipal > totalUnderlyingMinusSponsored();
 
         // _force is only allowed in full withdrawals, not partials, so this will
         // implicitly be false essentially preventing "partial withdrawals at a loss"

--- a/contracts/Vault.sol
+++ b/contracts/Vault.sol
@@ -443,8 +443,7 @@ contract Vault is
             underlyingAmount,
             msg.sender,
             address(0),
-            lockedUntil,
-            0
+            lockedUntil
         );
         totalSponsored += underlyingAmount;
 
@@ -834,8 +833,7 @@ contract Vault is
             _amount,
             msg.sender,
             locals.claimerId,
-            _lockedUntil,
-            locals.newShares
+            _lockedUntil
         );
 
         emit DepositMinted(
@@ -890,8 +888,6 @@ contract Vault is
         if (_deposit.amount < _amount)
             revert VaultCannotWithdrawMoreThanAvailable();
 
-        bool isFull = _deposit.amount == _amount;
-
         // Amount of shares the _amount is worth
         uint256 amountShares = _computeShares(
             _amount,
@@ -918,10 +914,11 @@ contract Vault is
         totalShares -= sharesToBurn;
         totalPrincipal -= _amount;
 
+        bool isFull = _deposit.amount == _amount;
+
         if (isFull) {
             delete deposits[_tokenId];
         } else {
-            deposits[_tokenId].shares -= sharesToBurn;
             deposits[_tokenId].amount -= _amount;
         }
 

--- a/contracts/interfaces/CustomErrors.sol
+++ b/contracts/interfaces/CustomErrors.sol
@@ -51,6 +51,9 @@ interface CustomErrors {
     // Vault: cannot deposit when yield is negative
     error VaultCannotDepositWhenYieldNegative();
 
+    // Vault: cannot deposit when yield is negative
+    error VaultCannotWithdrawWhenYieldNegative();
+
     // Vault: nothing to do
     error VaultNothingToDo();
 

--- a/contracts/interfaces/CustomErrors.sol
+++ b/contracts/interfaces/CustomErrors.sol
@@ -51,6 +51,9 @@ interface CustomErrors {
     // Vault: cannot deposit when yield is negative
     error VaultCannotDepositWhenYieldNegative();
 
+    // Vault: cannot deposit when the claimer is in debt
+    error VaultCannotDepositWhenClaimerInDebt();
+
     // Vault: cannot deposit when yield is negative
     error VaultCannotWithdrawWhenYieldNegative();
 

--- a/contracts/vault/IVault.sol
+++ b/contracts/vault/IVault.sol
@@ -31,8 +31,6 @@ interface IVault {
         address claimerId;
         /// when can the deposit be withdrawn
         uint256 lockedUntil;
-        /// the number of shares issued for this deposit
-        uint256 shares;
     }
 
     struct Claimer {

--- a/test/Vault.spec.ts
+++ b/test/Vault.spec.ts
@@ -863,7 +863,6 @@ describe('Vault', () => {
       const deposit = await vault.deposits(1);
       expect(deposit.amount).to.be.equals(parseUnits('500'));
       expect(deposit.lockedUntil).to.be.equal(currentTime.add(TWO_WEEKS));
-      expect(deposit.shares).to.be.equal(0);
     });
 
     it('transfers underlying from user at sponsor', async () => {
@@ -1643,11 +1642,9 @@ describe('Vault', () => {
 
       const deposit = await vault.deposits(1);
       expect(deposit.amount).to.eq(parseUnits('25'));
-      expect(deposit.shares).to.eq(parseUnits('37.5').mul(SHARES_MULTIPLIER));
 
       const deposit2 = await vault.deposits(2);
       expect(deposit2.amount).to.eq(parseUnits('20'));
-      expect(deposit2.shares).to.eq(parseUnits('35').mul(SHARES_MULTIPLIER));
     });
 
     it("reduces the claimer's totalShares and totalPrincipal", async () => {
@@ -1698,9 +1695,7 @@ describe('Vault', () => {
       const deposit = await vault.deposits(2);
 
       expect(deposit.amount).to.eq(0);
-      //expect(deposit.claimerId).to.eq(0);
       expect(deposit.lockedUntil).to.eq(0);
-      expect(deposit.shares).to.eq(0);
     });
 
     it('fails if the vault lost funds', async () => {
@@ -2216,18 +2211,12 @@ describe('Vault', () => {
       expect(deposit1.lockedUntil).to.be.equal(
         currentTime.add(params.lockDuration),
       );
-      expect(deposit1.shares).to.be.equal(
-        parseUnits('0.4').mul(SHARES_MULTIPLIER),
-      );
 
       const deposit2 = await vault.deposits(2);
       expect(deposit2.amount).to.be.equal(parseUnits('0.6'));
       expect(deposit2.claimerId).to.be.equal(carol.address);
       expect(deposit2.lockedUntil).to.be.equal(
         currentTime.add(params.lockDuration),
-      );
-      expect(deposit2.shares).to.be.equal(
-        parseUnits('0.6').mul(SHARES_MULTIPLIER),
       );
     });
   });

--- a/test/Vault.spec.ts
+++ b/test/Vault.spec.ts
@@ -1612,7 +1612,7 @@ describe('Vault', () => {
       const action = vault.connect(alice).withdraw(alice.address, [1]);
 
       await expect(action).to.be.revertedWith(
-        'VaultCannotWithdrawMoreThanAvailable',
+        'VaultCannotWithdrawWhenYieldNegative',
       );
     });
   });

--- a/test/audit_1.spec.ts
+++ b/test/audit_1.spec.ts
@@ -22,7 +22,7 @@ import {
 const { parseUnits } = ethers.utils;
 const { MaxUint256 } = ethers.constants;
 
-describe('Integration', () => {
+describe('Audit Tests 1', () => {
   let owner: SignerWithAddress;
   let alice: SignerWithAddress;
   let bob: SignerWithAddress;
@@ -103,10 +103,6 @@ describe('Integration', () => {
   });
 
   it('two deposits, single claimer. should fair for depositors', async () => {
-    await wrongCase();
-  });
-
-  async function wrongCase() {
     const [claimer, depositor1, depositor2] = [alice, bob, charlie];
 
     await addUnderlyingBalance(depositor1, '100000');
@@ -114,10 +110,10 @@ describe('Integration', () => {
 
     expect(await underlying.balanceOf(depositor1.address)).to.eq(
       parseUnits('100000'),
-    ); // depositor1 has 100000 underlying
+    );
     expect(await underlying.balanceOf(depositor2.address)).to.eq(
       parseUnits('100000'),
-    ); // depositor2 has 100000 underlying
+    );
 
     // ## depositor1 deposits
     await vault.connect(depositor1).deposit(
@@ -200,16 +196,16 @@ describe('Integration', () => {
 
     await expect(
       vault.connect(depositor1).withdraw(depositor1.address, [1]),
-    ).to.revertedWith('VaultCannotWithdrawWhenYieldNegative'); // FIXED!
+    ).to.revertedWith('VaultCannotWithdrawWhenYieldNegative');
 
     await vault.connect(depositor1).forceWithdraw(depositor1.address, [1]);
 
     expect(await underlying.balanceOf(vault.address)).to.eq(
       parseUnits('85000').add(1),
-    ); // vault: 170001 -> 70002  (sub 100000 - 1) FIXED!!!
+    );
     expect(await underlying.balanceOf(depositor1.address)).to.eq(
       parseUnits('85000'),
-    ); // depositor1: 0 -> 100000 - 1 (add 100000 - 1) FIXED!!!
+    );
 
     // ## depositor2 withdraw
     expect(await underlying.balanceOf(depositor2.address)).to.eq(
@@ -219,8 +215,8 @@ describe('Integration', () => {
     expect(await underlying.balanceOf(vault.address)).to.eq(parseUnits('0')); // vault: 70002 -> 0 (sub 70002)
     expect(await underlying.balanceOf(depositor2.address)).to.eq(
       parseUnits('85000').add(1),
-    ); // depositor2: 0 -> 70002 (add 70002) FIXED!!!
-  }
+    );
+  });
 
   function addYieldToVault(amount: string) {
     return underlying.mint(vault.address, parseUnits(amount));

--- a/test/audit_1.spec.ts
+++ b/test/audit_1.spec.ts
@@ -1,0 +1,238 @@
+import type { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
+import { time } from '@openzeppelin/test-helpers';
+import { ethers, deployments } from 'hardhat';
+import { expect } from 'chai';
+import { Contract, BigNumber } from 'ethers';
+
+import {
+  Vault,
+  MockUST,
+  MockStrategy,
+  MockAUST__factory,
+  MockUST__factory,
+  Vault__factory,
+} from '../typechain';
+import { depositParams, claimParams } from './shared/factories';
+import {
+  moveForwardTwoWeeks,
+  SHARES_MULTIPLIER,
+  generateNewAddress,
+} from './shared';
+
+const { parseUnits } = ethers.utils;
+const { MaxUint256 } = ethers.constants;
+
+describe('Integration', () => {
+  let owner: SignerWithAddress;
+  let alice: SignerWithAddress;
+  let bob: SignerWithAddress;
+  let charlie: SignerWithAddress;
+
+  let mockEthAnchorRouter: Contract;
+  let mockAUstUstFeed: Contract;
+
+  let underlying: MockUST;
+  let aUstToken: Contract;
+  let vault: Vault;
+  let strategy: MockStrategy;
+
+  const TWO_WEEKS = BigNumber.from(time.duration.weeks(2).toNumber());
+  const TREASURY = generateNewAddress();
+  const PERFORMANCE_FEE_PCT = BigNumber.from('00');
+  const INVESTMENT_FEE_PCT = BigNumber.from('200');
+  const INVEST_PCT = BigNumber.from('9000');
+
+  const fixtures = deployments.createFixture(async ({ deployments }) => {
+    await deployments.fixture(['vaults']);
+
+    [owner] = await ethers.getSigners();
+
+    const ustDeployment = await deployments.get('UST');
+    const austDeployment = await deployments.get('aUST');
+    const ustVaultDeployment = await deployments.get('Vault_UST');
+
+    aUstToken = MockAUST__factory.connect(austDeployment.address, owner);
+    underlying = MockUST__factory.connect(ustDeployment.address, owner);
+    vault = Vault__factory.connect(ustVaultDeployment.address, owner);
+  });
+
+  beforeEach(() => fixtures());
+
+  beforeEach(async () => {
+    [owner, alice, bob, charlie] = await ethers.getSigners();
+
+    let Vault = await ethers.getContractFactory('Vault');
+    let MockStrategy = await ethers.getContractFactory('MockStrategy');
+
+    const MockEthAnchorRouterFactory = await ethers.getContractFactory(
+      'MockEthAnchorRouter',
+    );
+    mockEthAnchorRouter = await MockEthAnchorRouterFactory.deploy(
+      underlying.address,
+      aUstToken.address,
+    );
+
+    const MockChainlinkPriceFeedFactory = await ethers.getContractFactory(
+      'MockChainlinkPriceFeed',
+    );
+    mockAUstUstFeed = await MockChainlinkPriceFeedFactory.deploy(18);
+
+    vault = await Vault.deploy(
+      underlying.address,
+      TWO_WEEKS,
+      INVEST_PCT,
+      TREASURY,
+      owner.address,
+      PERFORMANCE_FEE_PCT,
+      INVESTMENT_FEE_PCT,
+      [],
+    );
+
+    underlying.connect(owner).approve(vault.address, MaxUint256);
+    underlying.connect(alice).approve(vault.address, MaxUint256);
+    underlying.connect(bob).approve(vault.address, MaxUint256);
+    underlying.connect(charlie).approve(vault.address, MaxUint256);
+
+    strategy = await MockStrategy.deploy(
+      vault.address,
+      mockEthAnchorRouter.address,
+      mockAUstUstFeed.address,
+      underlying.address,
+      aUstToken.address,
+    );
+  });
+
+  it.only('two deposits, single claimer. should fair for depositors', async () => {
+    try {
+      await wrongCase();
+    } catch (e) {
+      return;
+    }
+    throw new Error('wrong case should throw');
+  });
+
+  async function wrongCase() {
+    const [claimer, depositor1, depositor2] = [alice, bob, charlie];
+
+    await addUnderlyingBalance(depositor1, '100000');
+    await addUnderlyingBalance(depositor2, '100000');
+
+    expect(await underlying.balanceOf(depositor1.address)).to.eq(
+      parseUnits('100000'),
+    ); // depositor1 has 100000 underlying
+    expect(await underlying.balanceOf(depositor2.address)).to.eq(
+      parseUnits('100000'),
+    ); // depositor2 has 100000 underlying
+
+    // ## depositor1 deposits
+    await vault.connect(depositor1).deposit(
+      depositParams.build({
+        amount: parseUnits('100000'),
+        inputToken: underlying.address,
+        claims: [claimParams.percent(100).to(claimer.address).build()],
+      }),
+    );
+
+    const deposit1 = await vault.deposits(1);
+    expect(deposit1.owner).to.equal(depositor1.address);
+    expect(deposit1.amount).to.equal(parseUnits('100000'));
+
+    expect(await vault.totalShares()).to.equal(
+      parseUnits('100000').mul(SHARES_MULTIPLIER),
+    );
+    expect(await vault.principalOf(claimer.address)).to.equal(
+      parseUnits('100000'),
+    );
+
+    // ## depositor2 deposits
+    await vault.connect(depositor2).deposit(
+      depositParams.build({
+        amount: parseUnits('100000'),
+        inputToken: underlying.address,
+        claims: [claimParams.percent(100).to(claimer.address).build()],
+      }),
+    );
+
+    const deposit2 = await vault.deposits(2);
+    expect(deposit2.owner).to.equal(depositor2.address);
+    expect(deposit2.amount).to.equal(parseUnits('100000'));
+
+    expect(await vault.totalShares()).to.equal(
+      parseUnits('200000').mul(SHARES_MULTIPLIER),
+    );
+    expect(await vault.principalOf(claimer.address)).to.equal(
+      parseUnits('200000'),
+    );
+
+    expect(await underlying.balanceOf(depositor1.address)).to.eq(
+      parseUnits('0'),
+    ); // depositor1: 100000 -> 0
+    expect(await underlying.balanceOf(depositor2.address)).to.eq(
+      parseUnits('0'),
+    ); // depositor2: 100000 -> 0
+    expect(await underlying.balanceOf(vault.address)).to.eq(
+      parseUnits('200000'),
+    ); // vault: 0 -> 200000
+
+    // ## add yield
+    await addYieldToVault('40000');
+    expect(await underlying.balanceOf(vault.address)).to.eq(
+      parseUnits('240000'),
+    ); // vault: 200000 -> 240000
+
+    // ## claimer
+    expect(await underlying.balanceOf(claimer.address)).to.eq(parseUnits('0'));
+    await vault.connect(claimer).claimYield(claimer.address);
+    expect(await underlying.balanceOf(claimer.address)).to.eq(
+      parseUnits('40000').sub(1),
+    ); // claimer: 0 -> 40000 - 1
+    expect(await underlying.balanceOf(vault.address)).to.eq(
+      parseUnits('200000').add(1),
+    ); // vault: 240000 -> 200001
+
+    // ## restore price per share
+    await removeUnderlyingFromVault('30000');
+    expect(await underlying.balanceOf(vault.address)).to.eq(
+      parseUnits('170000').add(1),
+    ); // vault: 200001 -> 170001
+
+    await moveForwardTwoWeeks();
+
+    // ## depositor1 withdraw
+    expect(await underlying.balanceOf(depositor1.address)).to.eq(
+      parseUnits('0'),
+    );
+    await vault.connect(depositor1).withdraw(depositor1.address, [1]);
+    expect(await underlying.balanceOf(vault.address)).to.eq(
+      parseUnits('70000').add(2),
+    ); // vault: 170001 -> 70002  (sub 100000 - 1)
+    expect(await underlying.balanceOf(depositor1.address)).to.eq(
+      parseUnits('100000').sub(1),
+    ); // depositor1: 0 -> 100000 - 1 (add 100000 - 1)
+
+    // ## depositor2 withdraw
+    expect(await underlying.balanceOf(depositor2.address)).to.eq(
+      parseUnits('0'),
+    );
+    await vault.connect(depositor2).forceWithdraw(depositor2.address, [2]);
+    expect(await underlying.balanceOf(vault.address)).to.eq(parseUnits('0')); // vault: 70002 -> 0 (sub 70002)
+    expect(await underlying.balanceOf(depositor2.address)).to.eq(
+      parseUnits('70000').add(2),
+    ); // depositor2: 0 -> 70002 (add 70002)
+  }
+
+  function addYieldToVault(amount: string) {
+    return underlying.mint(vault.address, parseUnits(amount));
+  }
+
+  function removeUnderlyingFromVault(amount: string) {
+    return underlying.burn(vault.address, parseUnits(amount));
+  }
+
+  async function addUnderlyingBalance(
+    account: SignerWithAddress,
+    amount: string,
+  ) {
+    await underlying.mint(account.address, parseUnits(amount));
+  }
+});

--- a/test/audit_1.spec.ts
+++ b/test/audit_1.spec.ts
@@ -102,13 +102,8 @@ describe('Integration', () => {
     );
   });
 
-  it.only('two deposits, single claimer. should fair for depositors', async () => {
-    try {
-      await wrongCase();
-    } catch (e) {
-      return;
-    }
-    throw new Error('wrong case should throw');
+  it('two deposits, single claimer. should fair for depositors', async () => {
+    await wrongCase();
   });
 
   async function wrongCase() {
@@ -202,13 +197,19 @@ describe('Integration', () => {
     expect(await underlying.balanceOf(depositor1.address)).to.eq(
       parseUnits('0'),
     );
-    await vault.connect(depositor1).withdraw(depositor1.address, [1]);
+
+    await expect(
+      vault.connect(depositor1).withdraw(depositor1.address, [1]),
+    ).to.revertedWith('VaultCannotWithdrawWhenYieldNegative'); // FIXED!
+
+    await vault.connect(depositor1).forceWithdraw(depositor1.address, [1]);
+
     expect(await underlying.balanceOf(vault.address)).to.eq(
-      parseUnits('70000').add(2),
-    ); // vault: 170001 -> 70002  (sub 100000 - 1)
+      parseUnits('85000').add(1),
+    ); // vault: 170001 -> 70002  (sub 100000 - 1) FIXED!!!
     expect(await underlying.balanceOf(depositor1.address)).to.eq(
-      parseUnits('100000').sub(1),
-    ); // depositor1: 0 -> 100000 - 1 (add 100000 - 1)
+      parseUnits('85000'),
+    ); // depositor1: 0 -> 100000 - 1 (add 100000 - 1) FIXED!!!
 
     // ## depositor2 withdraw
     expect(await underlying.balanceOf(depositor2.address)).to.eq(
@@ -217,8 +218,8 @@ describe('Integration', () => {
     await vault.connect(depositor2).forceWithdraw(depositor2.address, [2]);
     expect(await underlying.balanceOf(vault.address)).to.eq(parseUnits('0')); // vault: 70002 -> 0 (sub 70002)
     expect(await underlying.balanceOf(depositor2.address)).to.eq(
-      parseUnits('70000').add(2),
-    ); // depositor2: 0 -> 70002 (add 70002)
+      parseUnits('85000').add(1),
+    ); // depositor2: 0 -> 70002 (add 70002) FIXED!!!
   }
 
   function addYieldToVault(amount: string) {

--- a/test/audit_2.spec.ts
+++ b/test/audit_2.spec.ts
@@ -84,7 +84,7 @@ describe('Integration', () => {
       aUstToken.address,
     );
   });
-  describe.only('Vault / PPS manipulation', () => {
+  describe('Vault / PPS manipulation', () => {
     it('price per share can be manipulated', async () => {
       await addUnderlyingBalance(alice, '10000');
       await underlying.mint(bob.address, parseUnits('10000'));

--- a/test/audit_2.spec.ts
+++ b/test/audit_2.spec.ts
@@ -1,0 +1,222 @@
+import type { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
+import { time } from '@openzeppelin/test-helpers';
+import { ethers, deployments } from 'hardhat';
+import { expect } from 'chai';
+import { Contract, BigNumber } from 'ethers';
+import {
+  Vault,
+  MockUST,
+  MockStrategy,
+  MockAUST__factory,
+  MockUST__factory,
+  Vault__factory,
+} from '../typechain';
+import { depositParams, claimParams } from './shared/factories';
+import {
+  moveForwardTwoWeeks,
+  SHARES_MULTIPLIER,
+  generateNewAddress,
+} from './shared';
+const { parseUnits } = ethers.utils;
+const { MaxUint256 } = ethers.constants;
+describe('Integration', () => {
+  let owner: SignerWithAddress;
+  let alice: SignerWithAddress;
+  let bob: SignerWithAddress;
+  let charlie: SignerWithAddress;
+  let mockEthAnchorRouter: Contract;
+  let mockAUstUstFeed: Contract;
+  let underlying: MockUST;
+  let aUstToken: Contract;
+  let vault: Vault;
+  let strategy: MockStrategy;
+  const TWO_WEEKS = BigNumber.from(time.duration.weeks(2).toNumber());
+  const TREASURY = generateNewAddress();
+  const PERFORMANCE_FEE_PCT = BigNumber.from('00');
+  const INVESTMENT_FEE_PCT = BigNumber.from('200');
+  const INVEST_PCT = BigNumber.from('9000');
+  const fixtures = deployments.createFixture(async ({ deployments }) => {
+    await deployments.fixture(['vaults']);
+    [owner] = await ethers.getSigners();
+    const ustDeployment = await deployments.get('UST');
+    const austDeployment = await deployments.get('aUST');
+    const ustVaultDeployment = await deployments.get('Vault_UST');
+    aUstToken = MockAUST__factory.connect(austDeployment.address, owner);
+    underlying = MockUST__factory.connect(ustDeployment.address, owner);
+    vault = Vault__factory.connect(ustVaultDeployment.address, owner);
+  });
+  beforeEach(() => fixtures());
+  beforeEach(async () => {
+    [owner, alice, bob, charlie] = await ethers.getSigners();
+    let Vault = await ethers.getContractFactory('Vault');
+    let MockStrategy = await ethers.getContractFactory('MockStrategy');
+    const MockEthAnchorRouterFactory = await ethers.getContractFactory(
+      'MockEthAnchorRouter',
+    );
+    mockEthAnchorRouter = await MockEthAnchorRouterFactory.deploy(
+      underlying.address,
+      aUstToken.address,
+    );
+    const MockChainlinkPriceFeedFactory = await ethers.getContractFactory(
+      'MockChainlinkPriceFeed',
+    );
+    mockAUstUstFeed = await MockChainlinkPriceFeedFactory.deploy(18);
+    vault = await Vault.deploy(
+      underlying.address,
+      // TWO_WEEKS,
+      1,
+      INVEST_PCT,
+      TREASURY,
+      owner.address,
+      PERFORMANCE_FEE_PCT,
+      INVESTMENT_FEE_PCT,
+      [],
+    );
+    underlying.connect(owner).approve(vault.address, MaxUint256);
+    underlying.connect(alice).approve(vault.address, MaxUint256);
+    underlying.connect(bob).approve(vault.address, MaxUint256);
+    underlying.connect(charlie).approve(vault.address, MaxUint256);
+    strategy = await MockStrategy.deploy(
+      vault.address,
+      mockEthAnchorRouter.address,
+      mockAUstUstFeed.address,
+      underlying.address,
+      aUstToken.address,
+    );
+  });
+  describe.only('Vault / PPS manipulation', () => {
+    it('price per share can be manipulated', async () => {
+      await addUnderlyingBalance(alice, '10000');
+      await underlying.mint(bob.address, parseUnits('10000'));
+      await underlying.mint(charlie.address, parseUnits('10000'));
+      await vault.connect(alice).deposit(
+        depositParams.build({
+          inputToken: underlying.address,
+          lockDuration: 1,
+          amount: 1,
+          claims: [
+            claimParams.build({
+              beneficiary: alice.address,
+            }),
+          ],
+          name: 'test',
+        }),
+      );
+      // pps: 1/1e18; amount: 1; totalShares: 1e18;
+      console.log(
+        'after alice deposit 1: total shares',
+        await vault.totalShares(),
+      );
+      console.log(
+        'after alice deposit 1: amount',
+        await underlying.balanceOf(vault.address),
+      );
+      //transfer 1e18-1wei
+      await underlying.connect(alice).transfer(vault.address, 10n ** 18n - 1n);
+      // pps = 1, totalShares = 1e18 wei
+      console.log(
+        'transfer 1e18-1, and total shares',
+        await vault.totalShares(),
+      );
+      console.log(
+        'transfer 1e18-1, and amount',
+        await underlying.balanceOf(vault.address),
+      );
+      await vault.connect(bob).deposit(
+        depositParams.build({
+          inputToken: underlying.address,
+          lockDuration: 1,
+          amount: 1,
+          claims: [
+            claimParams.build({
+              beneficiary: bob.address,
+            }),
+          ],
+          name: 'test',
+        }),
+      );
+      // pps: 1, totalShares: 1e18+1 wei
+      console.log(
+        'after bob deposit 1: total shares',
+        await vault.totalShares(),
+      );
+      console.log(
+        'after bob deposit 1: amount',
+        await underlying.balanceOf(vault.address),
+      );
+      //time pass 1 day
+      await time.increase(24 * 60 * 60);
+      // await vault.connect(alice).withdraw(alice.address, [1]);
+      await vault.connect(alice).claimYield(alice.address);
+      await vault.connect(alice).withdraw(alice.address, [1]);
+      // pps: 1, totalShares: 1 wei
+      console.log('after alice exit: total shares', await vault.totalShares());
+      console.log(
+        'after alice exit: amount',
+        await vault.totalUnderlyingMinusSponsored(),
+      );
+      // await vault.connect(alice).withdraw(alice.address, [1]);
+      await underlying
+        .connect(bob)
+        .transfer(vault.address, (10n ** 18n - 1n).toString());
+      // await vault.connect(bob).withdraw(bob.address, [2]);
+      // pps: 1e18; totalShares: 1 wei
+      await vault.connect(bob).deposit(
+        depositParams.build({
+          inputToken: underlying.address,
+          lockDuration: 1,
+          amount: (199n * 10n ** 18n).toString(),
+          claims: [
+            claimParams.build({
+              beneficiary: bob.address,
+            }),
+          ],
+          name: 'test',
+        }),
+      );
+      console.log(
+        'after bob 2nd deposit: total shares',
+        await vault.totalShares(),
+      );
+      console.log(
+        'after bob 2nd deposit: total amount',
+        await vault.totalUnderlyingMinusSponsored(),
+      );
+      // bob shares: 100 wei
+      // victim
+      await vault.connect(charlie).deposit(
+        depositParams.build({
+          inputToken: underlying.address,
+          lockDuration: 1,
+          amount: (2n * 10n ** 18n - 1n).toString(),
+          claims: [
+            claimParams.build({
+              beneficiary: charlie.address,
+            }),
+          ],
+          name: 'test',
+        }),
+      );
+      const oldBalance = await underlying.balanceOf(charlie.address);
+      await vault.connect(charlie).claimYield(charlie.address);
+      await vault.connect(charlie).withdraw(charlie.address, [4]);
+      const newBalance = await underlying.balanceOf(charlie.address);
+      console.log(
+        'charlie: balance changed',
+        Number(newBalance) - Number(oldBalance),
+      );
+    });
+  });
+  function addYieldToVault(amount: string) {
+    return underlying.mint(vault.address, parseUnits(amount));
+  }
+  function removeUnderlyingFromVault(amount: string) {
+    return underlying.burn(vault.address, parseUnits(amount));
+  }
+  async function addUnderlyingBalance(
+    account: SignerWithAddress,
+    amount: string,
+  ) {
+    await underlying.mint(account.address, parseUnits(amount));
+  }
+});

--- a/test/audit_3.spec.ts
+++ b/test/audit_3.spec.ts
@@ -1,0 +1,368 @@
+import type { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
+import { time } from '@openzeppelin/test-helpers';
+import { ethers, deployments } from 'hardhat';
+import { expect } from 'chai';
+import { Contract, BigNumber } from 'ethers';
+import { Decimal } from 'decimal.js';
+
+import {
+  Vault,
+  MockUST,
+  MockStrategy,
+  MockAUST__factory,
+  MockUST__factory,
+  Vault__factory,
+} from '../typechain';
+import { depositParams, claimParams } from './shared/factories';
+import { moveForwardTwoWeeks, generateNewAddress } from './shared';
+
+const { parseUnits } = ethers.utils;
+const { MaxUint256, WeiPerEther } = ethers.constants;
+
+describe('wrong withdraw', () => {
+  let owner: SignerWithAddress;
+  let depositor1: SignerWithAddress;
+  let depositor2: SignerWithAddress;
+  let depositor3: SignerWithAddress;
+  let depositor4: SignerWithAddress;
+  let depositor5: SignerWithAddress;
+  let claimer1: SignerWithAddress;
+  let claimer2: SignerWithAddress;
+
+  let mockEthAnchorRouter: Contract;
+  let mockAUstUstFeed: Contract;
+
+  let underlying: MockUST;
+  let aUstToken: Contract;
+  let vault: Vault;
+  let strategy: MockStrategy;
+
+  const TWO_WEEKS = BigNumber.from(time.duration.weeks(2).toNumber());
+  const TREASURY = generateNewAddress();
+  const PERFORMANCE_FEE_PCT = BigNumber.from('00');
+  const INVESTMENT_FEE_PCT = BigNumber.from('200');
+  const INVEST_PCT = BigNumber.from('9000');
+
+  const fixtures = deployments.createFixture(async ({ deployments }) => {
+    await deployments.fixture(['vaults']);
+
+    [owner] = await ethers.getSigners();
+
+    const ustDeployment = await deployments.get('UST');
+    const austDeployment = await deployments.get('aUST');
+    const ustVaultDeployment = await deployments.get('Vault_UST');
+
+    aUstToken = MockAUST__factory.connect(austDeployment.address, owner);
+    underlying = MockUST__factory.connect(ustDeployment.address, owner);
+    vault = Vault__factory.connect(ustVaultDeployment.address, owner);
+  });
+
+  beforeEach(() => fixtures());
+
+  beforeEach(async () => {
+    [
+      owner,
+      depositor1,
+      depositor2,
+      depositor3,
+      depositor4,
+      depositor5,
+      claimer1,
+      claimer2,
+    ] = await ethers.getSigners();
+
+    let Vault = await ethers.getContractFactory('Vault');
+    let MockStrategy = await ethers.getContractFactory('MockStrategy');
+
+    const MockEthAnchorRouterFactory = await ethers.getContractFactory(
+      'MockEthAnchorRouter',
+    );
+    mockEthAnchorRouter = await MockEthAnchorRouterFactory.deploy(
+      underlying.address,
+      aUstToken.address,
+    );
+
+    const MockChainlinkPriceFeedFactory = await ethers.getContractFactory(
+      'MockChainlinkPriceFeed',
+    );
+    mockAUstUstFeed = await MockChainlinkPriceFeedFactory.deploy(18);
+
+    vault = await Vault.deploy(
+      underlying.address,
+      TWO_WEEKS,
+      INVEST_PCT,
+      TREASURY,
+      owner.address,
+      PERFORMANCE_FEE_PCT,
+      INVESTMENT_FEE_PCT,
+      [],
+    );
+
+    await underlying.connect(owner).approve(vault.address, MaxUint256);
+    await underlying.connect(depositor1).approve(vault.address, MaxUint256);
+    await underlying.connect(depositor2).approve(vault.address, MaxUint256);
+    await underlying.connect(depositor3).approve(vault.address, MaxUint256);
+    await underlying.connect(depositor4).approve(vault.address, MaxUint256);
+    await underlying.connect(depositor5).approve(vault.address, MaxUint256);
+
+    strategy = await MockStrategy.deploy(
+      vault.address,
+      mockEthAnchorRouter.address,
+      mockAUstUstFeed.address,
+      underlying.address,
+      aUstToken.address,
+    );
+  });
+
+  async function commonSteps() {
+    await addUnderlyingBalance(depositor1, '100000');
+    await addUnderlyingBalance(depositor2, '100000');
+    await addUnderlyingBalance(depositor3, '100000');
+    await addUnderlyingBalance(depositor4, '100000');
+    await addUnderlyingBalance(depositor5, '48000');
+
+    // ## depositor1 deposits
+    await vault.connect(depositor1).deposit(
+      depositParams.build({
+        amount: parseUnits('100000'),
+        inputToken: underlying.address,
+        claims: [claimParams.percent(100).to(claimer1.address).build()],
+      }),
+    );
+    // ## depositor2 deposits
+    await vault.connect(depositor2).deposit(
+      depositParams.build({
+        amount: parseUnits('100000'),
+        inputToken: underlying.address,
+        claims: [claimParams.percent(100).to(claimer1.address).build()],
+      }),
+    );
+    // ## depositor3 deposits
+    await vault.connect(depositor3).deposit(
+      depositParams.build({
+        amount: parseUnits('100000'),
+        inputToken: underlying.address,
+        claims: [claimParams.percent(100).to(claimer2.address).build()],
+      }),
+    );
+    // ## depositor4 deposits
+    await vault.connect(depositor4).deposit(
+      depositParams.build({
+        amount: parseUnits('100000'),
+        inputToken: underlying.address,
+        claims: [claimParams.percent(100).to(claimer2.address).build()],
+      }),
+    );
+    expect(await underlying.balanceOf(vault.address)).to.eq(
+      parseUnits('400000'),
+    ); // vault: 400k
+
+    // ## add yield
+    await addYieldToVault('100000');
+    expect(await underlying.balanceOf(vault.address)).to.eq(
+      parseUnits('500000'),
+    ); // vault: 500k = 400k + 100k
+
+    // ## claimer1 claimYield
+    expect(await underlying.balanceOf(claimer1.address)).to.eq(parseUnits('0'));
+    await vault.connect(claimer1).claimYield(claimer1.address);
+    expect(await underlying.balanceOf(claimer1.address)).to.eq(
+      parseUnits('50000'),
+    ); // claimer: 50k = 0 + 50k
+    expect(await underlying.balanceOf(vault.address)).to.eq(
+      parseUnits('450000'),
+    ); // vault: 450k = 500k - 50k
+
+    // ## price per share: 1.25 -> 1.2 (lost 18k)
+    await removeUnderlyingFromVault('18000');
+    expect(await underlying.balanceOf(vault.address)).to.eq(
+      parseUnits('432000'),
+    ); // vault: 432k = 450k - 18k
+  }
+
+  it('case 1', async () => {
+    await commonSteps();
+
+    await moveForwardTwoWeeks();
+
+    expect(await underlying.balanceOf(depositor1.address)).to.eq(
+      parseUnits('0'),
+    );
+    expect(await underlying.balanceOf(depositor2.address)).to.eq(
+      parseUnits('0'),
+    );
+    expect(await underlying.balanceOf(depositor3.address)).to.eq(
+      parseUnits('0'),
+    );
+    expect(await underlying.balanceOf(depositor4.address)).to.eq(
+      parseUnits('0'),
+    );
+    // ## depositor1 withdraw
+    await vault.connect(depositor1).forceWithdraw(depositor1.address, [1]);
+    // expect depositor1 forceWithdraw 96k but:
+    console.log(
+      'depositor1 underlying balance: ' +
+        (await underlying.balanceOf(depositor1.address)),
+    );
+
+    // ## depositor2 withdraw
+    await vault.connect(depositor2).forceWithdraw(depositor2.address, [2]);
+    // expect depositor2 forceWithdraw 96k but:
+    console.log(
+      'depositor2 underlying balance: ' +
+        (await underlying.balanceOf(depositor2.address)),
+    );
+
+    // ## claimer2 claimYield
+    expect(await underlying.balanceOf(claimer2.address)).to.eq(parseUnits('0'));
+    await vault.connect(claimer2).claimYield(claimer2.address);
+    expect(await underlying.balanceOf(claimer2.address)).to.eq(
+      parseUnits('40000').sub(1),
+    );
+
+    // ## depositor3 withdraw
+    expect(await underlying.balanceOf(depositor3.address)).to.eq(
+      parseUnits('0'),
+    );
+    // expect depositor3 can normally withdraw
+    await vault.connect(depositor3).withdraw(depositor3.address, [3]);
+    expect(await underlying.balanceOf(depositor3.address)).to.eq(
+      parseUnits('100000').sub(1),
+    );
+    console.log(
+      'depositor3 underlying balance: ' +
+        (await underlying.balanceOf(depositor3.address)),
+    );
+    // ## depositor4 withdraw
+    expect(await underlying.balanceOf(depositor4.address)).to.eq(
+      parseUnits('0'),
+    );
+    // expect depositor4 can normally withdraw
+    await vault.connect(depositor4).withdraw(depositor4.address, [4]);
+    console.log(
+      'depositor4 underlying balance: ' +
+        (await underlying.balanceOf(depositor4.address)),
+    );
+
+    console.log(
+      'claimer1 underlying balance: ' +
+        (await underlying.balanceOf(claimer1.address)),
+    );
+    console.log(
+      'claimer2 underlying balance: ' +
+        (await underlying.balanceOf(claimer2.address)),
+    );
+    console.log(
+      'vault underlying balance: ' +
+        (await underlying.balanceOf(vault.address)),
+    );
+  });
+
+  it('case 2', async () => {
+    await commonSteps();
+
+    // ## depositor5 canno withdraw because claimer is in debt
+    await expect(
+      vault.connect(depositor5).deposit(
+        depositParams.build({
+          amount: parseUnits('48000'),
+          inputToken: underlying.address,
+          claims: [claimParams.percent(100).to(claimer1.address).build()],
+        }),
+      ),
+    ).revertedWith('VaultCannotDepositWhenClaimerInDebt');
+
+    await moveForwardTwoWeeks();
+
+    expect(await underlying.balanceOf(depositor1.address)).to.eq(
+      parseUnits('0'),
+    );
+    expect(await underlying.balanceOf(depositor2.address)).to.eq(
+      parseUnits('0'),
+    );
+    expect(await underlying.balanceOf(depositor3.address)).to.eq(
+      parseUnits('0'),
+    );
+    expect(await underlying.balanceOf(depositor4.address)).to.eq(
+      parseUnits('0'),
+    );
+
+    // ## depositor1 withdraw
+    await expect(
+      vault.connect(depositor1).withdraw(depositor1.address, [1]),
+    ).to.revertedWith('VaultCannotWithdrawMoreThanAvailable');
+
+    await vault.connect(depositor1).forceWithdraw(depositor1.address, [1]);
+
+    expect(await underlying.balanceOf(depositor1.address)).to.eq(
+      parseUnits('96000'),
+    );
+
+    // ## depositor2 withdraw
+    await vault.connect(depositor2).forceWithdraw(depositor2.address, [2]);
+
+    expect(await underlying.balanceOf(depositor1.address)).to.eq(
+      parseUnits('96000'),
+    );
+
+    // ## claimer2 claimYield
+    expect(await underlying.balanceOf(claimer2.address)).to.eq(parseUnits('0'));
+    await vault.connect(claimer2).claimYield(claimer2.address);
+    expect(await underlying.balanceOf(claimer2.address)).to.eq(
+      parseUnits('40000').sub(1),
+    );
+
+    // ## depositor3 withdraw
+    expect(await underlying.balanceOf(depositor3.address)).to.eq(
+      parseUnits('0'),
+    );
+    // expect depositor3 can normally withdraw but must use forceWithdraw
+    await vault.connect(depositor3).forceWithdraw(depositor3.address, [3]);
+    expect(await underlying.balanceOf(depositor3.address)).to.eq(
+      parseUnits('100000').sub(1),
+    );
+    console.log(
+      'depositor3 underlying balance: ' +
+        (await underlying.balanceOf(depositor3.address)),
+    );
+
+    // ## depositor4 withdraw
+    expect(await underlying.balanceOf(depositor4.address)).to.eq(
+      parseUnits('0'),
+    );
+    // expect depositor4 can normally withdraw but must use forceWithdraw
+    await vault.connect(depositor4).forceWithdraw(depositor4.address, [4]);
+    console.log(
+      'depositor4 underlying balance: ' +
+        (await underlying.balanceOf(depositor4.address)),
+    );
+
+    console.log(
+      'claimer1 underlying balance: ' +
+        (await underlying.balanceOf(claimer1.address)),
+    );
+    console.log(
+      'claimer2 underlying balance: ' +
+        (await underlying.balanceOf(claimer2.address)),
+    );
+    console.log(
+      'vault underlying balance: ' +
+        (await underlying.balanceOf(vault.address)),
+    );
+  });
+
+  function addYieldToVault(amount: string) {
+    return underlying.mint(vault.address, parseUnits(amount));
+  }
+
+  function removeUnderlyingFromVault(amount: string) {
+    return underlying.burn(vault.address, parseUnits(amount));
+  }
+
+  async function addUnderlyingBalance(
+    account: SignerWithAddress,
+    amount: string,
+  ) {
+    await underlying.mint(account.address, parseUnits(amount));
+  }
+});

--- a/test/audit_3.spec.ts
+++ b/test/audit_3.spec.ts
@@ -3,7 +3,6 @@ import { time } from '@openzeppelin/test-helpers';
 import { ethers, deployments } from 'hardhat';
 import { expect } from 'chai';
 import { Contract, BigNumber } from 'ethers';
-import { Decimal } from 'decimal.js';
 
 import {
   Vault,

--- a/test/audit_3.spec.ts
+++ b/test/audit_3.spec.ts
@@ -19,7 +19,7 @@ import { moveForwardTwoWeeks, generateNewAddress } from './shared';
 const { parseUnits } = ethers.utils;
 const { MaxUint256, WeiPerEther } = ethers.constants;
 
-describe('wrong withdraw', () => {
+describe('Audit Tests 3', () => {
   let owner: SignerWithAddress;
   let depositor1: SignerWithAddress;
   let depositor2: SignerWithAddress;
@@ -129,6 +129,7 @@ describe('wrong withdraw', () => {
         claims: [claimParams.percent(100).to(claimer1.address).build()],
       }),
     );
+
     // ## depositor2 deposits
     await vault.connect(depositor2).deposit(
       depositParams.build({
@@ -137,6 +138,7 @@ describe('wrong withdraw', () => {
         claims: [claimParams.percent(100).to(claimer1.address).build()],
       }),
     );
+
     // ## depositor3 deposits
     await vault.connect(depositor3).deposit(
       depositParams.build({
@@ -145,6 +147,7 @@ describe('wrong withdraw', () => {
         claims: [claimParams.percent(100).to(claimer2.address).build()],
       }),
     );
+
     // ## depositor4 deposits
     await vault.connect(depositor4).deposit(
       depositParams.build({
@@ -153,6 +156,7 @@ describe('wrong withdraw', () => {
         claims: [claimParams.percent(100).to(claimer2.address).build()],
       }),
     );
+
     expect(await underlying.balanceOf(vault.address)).to.eq(
       parseUnits('400000'),
     ); // vault: 400k
@@ -197,6 +201,7 @@ describe('wrong withdraw', () => {
     expect(await underlying.balanceOf(depositor4.address)).to.eq(
       parseUnits('0'),
     );
+
     // ## depositor1 withdraw
     await vault.connect(depositor1).forceWithdraw(depositor1.address, [1]);
     // expect depositor1 forceWithdraw 96k but:

--- a/test/integration.spec.ts
+++ b/test/integration.spec.ts
@@ -163,7 +163,7 @@ describe('Integration', () => {
       // we expect the withdraw to fail because there are not enough funds in the vault
       await expect(
         vault.connect(alice).withdraw(alice.address, [2]),
-      ).to.be.revertedWith('CannotComputeSharesWithoutPrincipal');
+      ).to.be.revertedWith('VaultCannotWithdrawWhenYieldNegative');
       await vault.connect(bob).unsponsor(bob.address, [1]);
 
       expect(await underlyingBalanceOf(bob)).to.eq(parseUnits('1000'));


### PR DESCRIPTION
This change addresses the unfair distribution of loss:
* prevent deposits when the total underlying is less than the total principal.
* prevent deposits to users who are already in debt.
* update logic to calculate how many shares a deposit is worth during a withdrawal.
* removes shares from the deposit because this number is no longer needed with the update logic.
* add tests provided by the auditors.

A user is considered in debt when the vault loses funds after she claims the yield. At this point, this user will have to wait for the vault to generate the lost yield and some more before she can claim again. During this process, any deposit to this user would lose money immediately, and because of that, we need to prevent deposits.