### PR TITLE
Don't use tenderly during tests

### DIFF
--- a/deploy/01_devSetup.ts
+++ b/deploy/01_devSetup.ts
@@ -31,11 +31,12 @@ async function deployDevToken(
       log: true,
     });
 
-    await env.tenderly.persistArtifacts({
+    if (process.env.NODE_ENV !== 'test')
+      await env.tenderly.persistArtifacts({
         name,
         address: deployment.address,
-    })
-    
+      });
+
     if (process.env.NODE_ENV !== 'test') {
       for (let account of [deployer, alice, bob, carol]) {
         const decimals = await read(name, 'decimals');

--- a/deploy/96_fixtureDeployments.ts
+++ b/deploy/96_fixtureDeployments.ts
@@ -22,10 +22,11 @@ const func = async function (env: HardhatRuntimeEnvironment) {
     args: [mockUST.address, mockaUST.address],
   });
 
-  await env.tenderly.persistArtifacts({
+  if (process.env.NODE_ENV !== 'test')
+    await env.tenderly.persistArtifacts({
       name: 'MockEthAnchorRouter',
       address: mockEthAnchorRouterDeployment.address,
-  });
+    });
 
   const vaultDeployment = await get('Vault_UST');
   const vault = await ethers.getContractAt('Vault', vaultDeployment.address);
@@ -39,10 +40,11 @@ const func = async function (env: HardhatRuntimeEnvironment) {
     },
   );
 
-  await env.tenderly.persistArtifacts({
+  if (process.env.NODE_ENV !== 'test')
+    await env.tenderly.persistArtifacts({
       name: 'MockChainlinkPriceFeed',
       address: mockChainlinkPriceFeedDeployment.address,
-  });
+    });
 
   const anchorStrategyDeployment = await deploy('AnchorStrategy', {
     contract: 'AnchorStrategy',
@@ -58,10 +60,11 @@ const func = async function (env: HardhatRuntimeEnvironment) {
     log: true,
   });
 
-  await env.tenderly.persistArtifacts({
+  if (process.env.NODE_ENV !== 'test')
+    await env.tenderly.persistArtifacts({
       name: 'AnchorStrategy',
       address: anchorStrategyDeployment.address,
-  });
+    });
 
   const anchorStrategy = await ethers.getContractAt(
     'AnchorStrategy',

--- a/deploy/MockChainlinkPriceFeed.ts
+++ b/deploy/MockChainlinkPriceFeed.ts
@@ -12,10 +12,11 @@ const func: DeployFunction = async function (env: HardhatRuntimeEnvironment) {
     args: [18],
   });
 
-  await env.tenderly.persistArtifacts({
+  if (process.env.NODE_ENV !== 'test')
+    await env.tenderly.persistArtifacts({
       name: 'ChainlinkPriceFeed',
       address: deployment.address,
-  });
+    });
 };
 
 func.id = 'deploy_mock_price_feed';

--- a/deploy/UST.anchorStrategy.ts
+++ b/deploy/UST.anchorStrategy.ts
@@ -33,10 +33,11 @@ const func: DeployFunction = async function (env: HardhatRuntimeEnvironment) {
     args,
   });
 
-  await env.tenderly.persistArtifacts({
+  if (process.env.NODE_ENV !== 'test')
+    await env.tenderly.persistArtifacts({
       name: 'Vault_UST_AnchorStrategy',
       address: strategyDeployment.address,
-  });
+    });
 
   if (env.network.config.chainId === 1 || env.network.config.chainId === 3) {
     try {

--- a/deploy/UST.vault.ts
+++ b/deploy/UST.vault.ts
@@ -58,10 +58,11 @@ const func: DeployFunction = async function (env: HardhatRuntimeEnvironment) {
     args,
   });
 
-  await env.tenderly.persistArtifacts({
+  if (process.env.NODE_ENV !== 'test')
+    await env.tenderly.persistArtifacts({
       name: 'Vault_UST',
       address: vaultDeployment.address,
-  });
+    });
 
   if (env.network.config.chainId === 1 || env.network.config.chainId === 3) {
     try {

--- a/deploy/donations.ts
+++ b/deploy/donations.ts
@@ -19,12 +19,16 @@ const func: DeployFunction = async function (env: HardhatRuntimeEnvironment) {
     args,
   });
 
-  await env.tenderly.persistArtifacts({
+  if (process.env.NODE_ENV !== 'test')
+    await env.tenderly.persistArtifacts({
       name: 'Donations',
       address: donationsDeployment.address,
-  });
+    });
 
-  if (env.network.config.chainId === 80001 || env.network.config.chainId === 137) {
+  if (
+    env.network.config.chainId === 80001 ||
+    env.network.config.chainId === 137
+  ) {
     try {
       await env.run('verify:verify', {
         address: donationsDeployment.address,

--- a/deploy/helpers/mockPool.ts
+++ b/deploy/helpers/mockPool.ts
@@ -22,12 +22,17 @@ async function deployMockCurvePool(
     return;
   }
 
-  const deployment = await deploy(name, { contract: 'MockCurve', from: deployer, args: [] });
+  const deployment = await deploy(name, {
+    contract: 'MockCurve',
+    from: deployer,
+    args: [],
+  });
 
-  await env.tenderly.persistArtifacts({
+  if (process.env.NODE_ENV !== 'test')
+    await env.tenderly.persistArtifacts({
       name: 'MockCurve',
       address: deployment.address,
-  });
+    });
 
   await execute(name, { from: deployer }, 'addToken', 0, underlying.address);
 


### PR DESCRIPTION
Because we are pushing artifacts to tenderly during tests, the tests became super slow.