### PR TITLE
Subgraph Modules Gitkeep to Persist Symbolic Links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
-node_modules
+/node_modules
+!/subgraph/node_modules/.gitkeep
+/subgraph/node_modules/*
 
 #Hardhat files
 cache

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 /node_modules
-!/subgraph/node_modules/.gitkeep
 /subgraph/node_modules/*
+!/subgraph/node_modules/.gitkeep
 
 #Hardhat files
 cache

--- a/subgraph/ethereum/node_modules
+++ b/subgraph/ethereum/node_modules
@@ -1,0 +1,1 @@
+../node_modules

--- a/subgraph/polygon/node_modules
+++ b/subgraph/polygon/node_modules
@@ -1,0 +1,1 @@
+../node_modules


### PR DESCRIPTION
- Add .gitkeep to subgraph node_modules folder so that symbolic links get committed