### PR TITLE
Deposit Reverts if Provided Metavault Name is too Short

### DIFF
--- a/contracts/Vault.sol
+++ b/contracts/Vault.sol
@@ -259,6 +259,7 @@ contract Vault is
             _params.lockDuration < minLockPeriod ||
             _params.lockDuration > MAX_DEPOSIT_LOCK_DURATION
         ) revert VaultInvalidLockPeriod();
+        if (bytes(_params.name).length < 4) revert VaultDepositNameTooShort();
 
         uint256 principalMinusStrategyFee = _applyLossTolerance(totalPrincipal);
         uint256 previousTotalUnderlying = totalUnderlyingMinusSponsored();

--- a/contracts/interfaces/CustomErrors.sol
+++ b/contracts/interfaces/CustomErrors.sol
@@ -111,6 +111,9 @@ interface CustomErrors {
     // Vault: cannot compute shares when there's no principal
     error VaultCannotComputeSharesWithoutPrincipal();
 
+    // Vault: deposit name for MetaVault too short
+    error VaultDepositNameTooShort();
+
     //
     // Strategy Errors
     //

--- a/test/Vault.spec.ts
+++ b/test/Vault.spec.ts
@@ -1223,6 +1223,19 @@ describe('Vault', () => {
       await vault.connect(owner).unpause();
     });
 
+    it('reverts if provided MetaVault name is too short', async () => {
+      const params = depositParams.build({
+        lockDuration: TWO_WEEKS,
+        amount: parseUnits('100'),
+        inputToken: underlying.address,
+        claims: [],
+        name: 'abc', // three utf8 characters
+      });
+      await expect(vault.connect(owner).deposit(params)).to.be.revertedWith(
+        'VaultDepositNameTooShort()',
+      );
+    });
+
     it('applies the loss tolerance before preventing a deposit', async () => {
       await vault.connect(alice).deposit(
         depositParams.build({


### PR DESCRIPTION
- Deposit reverts if provided metavault name is too short
- Character length counted in utf8 characters
  - This handles most expected cases without implementing a very gas inefficient way of doing the check
- Four utf8 characters expected minimum