### PR TITLE
[L-6] Use type(uint256).max when investing to Yearn Vault

### DIFF
--- a/contracts/mock/yearn/MockYearnVault.sol
+++ b/contracts/mock/yearn/MockYearnVault.sol
@@ -25,8 +25,15 @@ contract MockYearnVault is IYearnVault, ERC20 {
         returns (uint256)
     {
         require(amount > 0);
-        underlying.safeTransferFrom(msg.sender, address(this), amount);
-        return _issueSharesForAmount(recipient, amount);
+
+        uint256 newAmount = amount;
+
+        if (amount == type(uint256).max)
+            newAmount = underlying.balanceOf(msg.sender);
+
+        underlying.safeTransferFrom(msg.sender, address(this), newAmount);
+
+        return _issueSharesForAmount(recipient, newAmount);
     }
 
     function pricePerShare() public view returns (uint256) {

--- a/contracts/strategy/yearn/YearnStrategy.sol
+++ b/contracts/strategy/yearn/YearnStrategy.sol
@@ -136,12 +136,14 @@ contract YearnStrategy is IStrategy, AccessControl, Ownable, CustomErrors {
 
     /// @inheritdoc IStrategy
     function invest() external virtual override(IStrategy) onlyManager {
-        uint256 balance = _getUnderlyingBalance();
-        if (balance == 0) revert StrategyNoUnderlying();
+        uint256 beforeBalance = _getUnderlyingBalance();
+        if (beforeBalance == 0) revert StrategyNoUnderlying();
 
-        yVault.deposit(balance, address(this));
+        yVault.deposit(type(uint256).max, address(this));
 
-        emit StrategyInvested(balance);
+        uint256 afterBalance = _getUnderlyingBalance();
+
+        emit StrategyInvested(beforeBalance - afterBalance);
     }
 
     /// @inheritdoc IStrategy

--- a/test/strategy/yearn/YearnStrategy.spec.ts
+++ b/test/strategy/yearn/YearnStrategy.spec.ts
@@ -270,6 +270,30 @@ describe('YearnStrategy', () => {
       expect(await strategy.investedAssets()).to.eq(parseEther('70'));
     });
 
+    it('removes the requested funds from the strategy', async () => {
+      await underlying.mint(strategy.address, parseEther('100'));
+
+      await strategy.connect(manager).withdrawToVault(parseEther('30'));
+
+      expect(await yVault.balanceOf(strategy.address)).to.eq(parseEther('0'));
+      expect(await strategy.investedAssets()).to.eq(parseEther('70'));
+      expect(await underlying.balanceOf(vault.address)).to.eq(parseEther('30'));
+    });
+
+    it('removes the requested funds from the strategy and the yVault', async () => {
+      await depositToVault(parseEther('100'));
+      await vault.connect(owner).updateInvested();
+      await underlying.mint(strategy.address, parseEther('10'));
+
+      await strategy.connect(manager).withdrawToVault(parseEther('30'));
+
+      expect(await yVault.balanceOf(strategy.address)).to.eq(parseEther('80'));
+      expect(await underlying.balanceOf(strategy.address)).to.eq(
+        parseEther('0'),
+      );
+      expect(await underlying.balanceOf(vault.address)).to.eq(parseEther('30'));
+    });
+
     it('emits an event', async () => {
       await depositToVault(parseEther('100'));
       await vault.connect(owner).updateInvested();


### PR DESCRIPTION
Yearn vaults have a max for deposit amounts. Using `type(uint256).max`
will make the Yearn vault invest the full amount or what is possible.