### PR TITLE
Ownable removed from YearnStrategy Contract

### DIFF
--- a/contracts/interfaces/CustomErrors.sol
+++ b/contracts/interfaces/CustomErrors.sol
@@ -136,6 +136,9 @@ interface CustomErrors {
     // Strategy: caller has no settings role
     error StrategyCallerNotSettings();
 
+    // Strategy: caller is not the owner
+    error StrategyCallerNotOwner();
+
     // Strategy: amount is 0
     error StrategyAmountZero();
 

--- a/contracts/interfaces/CustomErrors.sol
+++ b/contracts/interfaces/CustomErrors.sol
@@ -118,11 +118,11 @@ interface CustomErrors {
     // Strategy Errors
     //
 
-    // Strategy: owner is 0x
-    error StrategyOwnerCannotBe0Address();
+    // Strategy: admin is 0x
+    error StrategyAdminCannotBe0Address();
 
-    // Strategy: cannot transfer ownership to self
-    error StrategyCannotTransferOwnershipToSelf();
+    // Strategy: cannot transfer admin rights to self
+    error StrategyCannotTransferAdminRightsToSelf();
 
     // Strategy: underlying is 0x
     error StrategyUnderlyingCannotBe0Address();
@@ -136,8 +136,8 @@ interface CustomErrors {
     // Strategy: caller has no settings role
     error StrategyCallerNotSettings();
 
-    // Strategy: caller is not the owner
-    error StrategyCallerNotOwner();
+    // Strategy: caller is not admin
+    error StrategyCallerNotAdmin();
 
     // Strategy: amount is 0
     error StrategyAmountZero();

--- a/contracts/mock/anchor/AnchorStrategy.sol
+++ b/contracts/mock/anchor/AnchorStrategy.sol
@@ -85,7 +85,7 @@ contract AnchorStrategy is
      * @param _aUstToUstFeed aUST / UST chainlink feed address
      * @param _ustToken UST token address
      * @param _aUstToken aUST token address
-     * @param _owner Owner address
+     * @param _admin admin address
      */
     constructor(
         address _vault,
@@ -93,9 +93,9 @@ contract AnchorStrategy is
         AggregatorV3Interface _aUstToUstFeed,
         IERC20 _ustToken,
         IERC20 _aUstToken,
-        address _owner
+        address _admin
     ) {
-        if (_owner == address(0)) revert StrategyOwnerCannotBe0Address();
+        if (_admin == address(0)) revert StrategyAdminCannotBe0Address();
         if (_ethAnchorRouter == address(0))
             revert StrategyRouterCannotBe0Address();
         if (address(_ustToken) == address(0))
@@ -105,7 +105,7 @@ contract AnchorStrategy is
         if (!_vault.doesContractImplementInterface(type(IVault).interfaceId))
             revert StrategyNotIVault();
 
-        _setupRole(DEFAULT_ADMIN_ROLE, _owner);
+        _setupRole(DEFAULT_ADMIN_ROLE, _admin);
         _setupRole(MANAGER_ROLE, _vault);
 
         vault = _vault;

--- a/contracts/strategy/yearn/YearnStrategy.sol
+++ b/contracts/strategy/yearn/YearnStrategy.sol
@@ -117,7 +117,7 @@ contract YearnStrategy is IStrategy, AccessControl, CustomErrors {
      *
      * @param _newAdmin The new Strategy admin account.
      */
-    function transferAdminRights(address _newAdmin) public onlyAdmin {
+    function transferAdminRights(address _newAdmin) external onlyAdmin {
         if (_newAdmin == address(0x0)) revert StrategyAdminCannotBe0Address();
         if (_newAdmin == msg.sender)
             revert StrategyCannotTransferAdminRightsToSelf();

--- a/contracts/strategy/yearn/YearnStrategy.sol
+++ b/contracts/strategy/yearn/YearnStrategy.sol
@@ -18,7 +18,7 @@ import {IVault} from "../../vault/IVault.sol";
  *
  * @notice This strategy is syncrhonous (supports immediate withdrawals).
  */
-contract YearnStrategy is IStrategy, AccessControl, Ownable, CustomErrors {
+contract YearnStrategy is IStrategy, AccessControl, CustomErrors {
     using SafeERC20 for IERC20;
     using PercentMath for uint256;
     using ERC165Query for address;
@@ -99,6 +99,12 @@ contract YearnStrategy is IStrategy, AccessControl, Ownable, CustomErrors {
         _;
     }
 
+    modifier onlyOwner() {
+        if (!hasRole(DEFAULT_ADMIN_ROLE, msg.sender))
+            revert StrategyCallerNotOwner();
+        _;
+    }
+
     //
     // Ownable
     //
@@ -111,16 +117,10 @@ contract YearnStrategy is IStrategy, AccessControl, Ownable, CustomErrors {
      *
      * @param _newOwner The new owner of the contract.
      */
-    function transferOwnership(address _newOwner)
-        public
-        override(Ownable)
-        onlyOwner
-    {
+    function transferOwnership(address _newOwner) public onlyOwner {
         if (_newOwner == address(0x0)) revert StrategyOwnerCannotBe0Address();
         if (_newOwner == msg.sender)
             revert StrategyCannotTransferOwnershipToSelf();
-
-        _transferOwnership(_newOwner);
 
         _setupRole(DEFAULT_ADMIN_ROLE, _newOwner);
         _setupRole(SETTINGS_ROLE, _newOwner);

--- a/contracts/strategy/yearn/YearnStrategy.sol
+++ b/contracts/strategy/yearn/YearnStrategy.sol
@@ -3,7 +3,6 @@ pragma solidity =0.8.10;
 
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
-import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {AccessControl} from "@openzeppelin/contracts/access/AccessControl.sol";
 
 import {PercentMath} from "../../lib/PercentMath.sol";
@@ -104,10 +103,6 @@ contract YearnStrategy is IStrategy, AccessControl, CustomErrors {
             revert StrategyCallerNotAdmin();
         _;
     }
-
-    //
-    // Ownable
-    //
 
     /**
      * Transfers administrator rights for the Strategy to another account,

--- a/test/strategy/yearn/YearnStrategy.spec.ts
+++ b/test/strategy/yearn/YearnStrategy.spec.ts
@@ -152,7 +152,7 @@ describe('YearnStrategy', () => {
     it('can only be called by the current owner', async () => {
       await expect(
         strategy.connect(alice).transferOwnership(alice.address),
-      ).to.be.revertedWith('Ownable: caller is not the owner');
+      ).to.be.revertedWith('StrategyCallerNotOwner');
     });
 
     it('reverts if new owner is address(0)', async () => {
@@ -168,9 +168,14 @@ describe('YearnStrategy', () => {
     });
 
     it('changes ownership to the new owner', async () => {
+      let DEFAULT_ADMIN_ROLE = await strategy.DEFAULT_ADMIN_ROLE();
+      expect(
+        await strategy.hasRole(DEFAULT_ADMIN_ROLE, alice.address),
+      ).to.be.equal(false);
       await strategy.connect(owner).transferOwnership(alice.address);
-
-      expect(await strategy.owner()).to.be.equal(alice.address);
+      expect(
+        await strategy.hasRole(DEFAULT_ADMIN_ROLE, alice.address),
+      ).to.be.equal(true);
     });
 
     it("revokes previous owner's ADMIN role and sets up ADMIN role for the new owner", async () => {

--- a/test/strategy/yearn/YearnStrategy.spec.ts
+++ b/test/strategy/yearn/YearnStrategy.spec.ts
@@ -16,7 +16,7 @@ import { depositParams, claimParams } from '../../shared/factories';
 import { parseUnits } from 'ethers/lib/utils';
 
 describe('YearnStrategy', () => {
-  let owner: SignerWithAddress;
+  let admin: SignerWithAddress;
   let alice: SignerWithAddress;
   let manager: SignerWithAddress;
   let vault: Vault;
@@ -37,7 +37,7 @@ describe('YearnStrategy', () => {
   const MANAGER_ROLE = utils.keccak256(utils.toUtf8Bytes('MANAGER_ROLE'));
 
   beforeEach(async () => {
-    [owner, alice, manager] = await ethers.getSigners();
+    [admin, alice, manager] = await ethers.getSigners();
 
     const MockERC20 = await ethers.getContractFactory('MockERC20');
     underlying = await MockERC20.deploy(
@@ -62,7 +62,7 @@ describe('YearnStrategy', () => {
       MIN_LOCK_PERIOD,
       INVEST_PCT,
       TREASURY,
-      owner.address,
+      admin.address,
       PERFORMANCE_FEE_PCT,
       INVESTMENT_FEE_PCT,
       [],
@@ -72,22 +72,22 @@ describe('YearnStrategy', () => {
 
     strategy = await YearnStrategyFactory.deploy(
       vault.address,
-      owner.address,
+      admin.address,
       yVault.address,
       underlying.address,
     );
 
-    await strategy.connect(owner).grantRole(MANAGER_ROLE, manager.address);
+    await strategy.connect(admin).grantRole(MANAGER_ROLE, manager.address);
 
     await vault.setStrategy(strategy.address);
 
     await underlying
-      .connect(owner)
+      .connect(admin)
       .approve(vault.address, constants.MaxUint256);
   });
 
   describe('#constructor', () => {
-    it('reverts if owner is address(0)', async () => {
+    it('reverts if admin is address(0)', async () => {
       await expect(
         YearnStrategyFactory.deploy(
           vault.address,
@@ -95,14 +95,14 @@ describe('YearnStrategy', () => {
           yVault.address,
           underlying.address,
         ),
-      ).to.be.revertedWith('StrategyOwnerCannotBe0Address');
+      ).to.be.revertedWith('StrategyAdminCannotBe0Address');
     });
 
     it('reverts if the yearn vault is address(0)', async () => {
       await expect(
         YearnStrategyFactory.deploy(
           vault.address,
-          owner.address,
+          admin.address,
           constants.AddressZero,
           underlying.address,
         ),
@@ -113,7 +113,7 @@ describe('YearnStrategy', () => {
       await expect(
         YearnStrategyFactory.deploy(
           vault.address,
-          owner.address,
+          admin.address,
           yVault.address,
           constants.AddressZero,
         ),
@@ -124,7 +124,7 @@ describe('YearnStrategy', () => {
       await expect(
         YearnStrategyFactory.deploy(
           manager.address,
-          owner.address,
+          admin.address,
           yVault.address,
           underlying.address,
         ),
@@ -133,9 +133,9 @@ describe('YearnStrategy', () => {
 
     it('checks initial values', async () => {
       expect(await strategy.isSync()).to.be.true;
-      expect(await strategy.hasRole(DEFAULT_ADMIN_ROLE, owner.address)).to.be
+      expect(await strategy.hasRole(DEFAULT_ADMIN_ROLE, admin.address)).to.be
         .true;
-      expect(await strategy.hasRole(SETTINGS_ROLE, owner.address)).to.be.true;
+      expect(await strategy.hasRole(SETTINGS_ROLE, admin.address)).to.be.true;
       expect(await strategy.hasRole(MANAGER_ROLE, vault.address)).to.be.true;
       expect(await strategy.vault()).to.eq(vault.address);
       expect(await strategy.yVault()).to.eq(yVault.address);
@@ -148,47 +148,46 @@ describe('YearnStrategy', () => {
     });
   });
 
-  describe('#transferOwnership', () => {
-    it('can only be called by the current owner', async () => {
+  describe('#transferAdminRights', () => {
+    it('can only be called by the current admin', async () => {
       await expect(
-        strategy.connect(alice).transferOwnership(alice.address),
-      ).to.be.revertedWith('StrategyCallerNotOwner');
+        strategy.connect(alice).transferAdminRights(alice.address),
+      ).to.be.revertedWith('StrategyCallerNotAdmin');
     });
 
-    it('reverts if new owner is address(0)', async () => {
+    it('reverts if new admin is address(0)', async () => {
       await expect(
-        strategy.connect(owner).transferOwnership(constants.AddressZero),
-      ).to.be.revertedWith('StrategyOwnerCannotBe0Address');
+        strategy.connect(admin).transferAdminRights(constants.AddressZero),
+      ).to.be.revertedWith('StrategyAdminCannotBe0Address');
     });
 
-    it('reverts if the new owner is the same as the current one', async () => {
+    it('reverts if the new admin is the same as the current one', async () => {
       await expect(
-        strategy.connect(owner).transferOwnership(owner.address),
-      ).to.be.revertedWith('StrategyCannotTransferOwnershipToSelf');
+        strategy.connect(admin).transferAdminRights(admin.address),
+      ).to.be.revertedWith('StrategyCannotTransferAdminRightsToSelf');
     });
 
-    it('changes ownership to the new owner', async () => {
+    it('changes admin account to the new admin account', async () => {
       let DEFAULT_ADMIN_ROLE = await strategy.DEFAULT_ADMIN_ROLE();
       expect(
         await strategy.hasRole(DEFAULT_ADMIN_ROLE, alice.address),
       ).to.be.equal(false);
-      await strategy.connect(owner).transferOwnership(alice.address);
+      await strategy.connect(admin).transferAdminRights(alice.address);
       expect(
         await strategy.hasRole(DEFAULT_ADMIN_ROLE, alice.address),
       ).to.be.equal(true);
     });
 
-    it("revokes previous owner's ADMIN role and sets up ADMIN role for the new owner", async () => {
-      // assert that the owner has the ADMIN role
-      expect(await strategy.hasRole(DEFAULT_ADMIN_ROLE, owner.address)).to.be
+    it("revokes previous admin's roles and sets up the same roles for the new admin account", async () => {
+      expect(await strategy.hasRole(DEFAULT_ADMIN_ROLE, admin.address)).to.be
         .true;
-      expect(await strategy.hasRole(SETTINGS_ROLE, owner.address)).to.be.true;
+      expect(await strategy.hasRole(SETTINGS_ROLE, admin.address)).to.be.true;
 
-      await strategy.connect(owner).transferOwnership(alice.address);
+      await strategy.connect(admin).transferAdminRights(alice.address);
 
-      expect(await strategy.hasRole(DEFAULT_ADMIN_ROLE, owner.address)).to.be
+      expect(await strategy.hasRole(DEFAULT_ADMIN_ROLE, admin.address)).to.be
         .false;
-      expect(await strategy.hasRole(SETTINGS_ROLE, owner.address)).to.be.false;
+      expect(await strategy.hasRole(SETTINGS_ROLE, admin.address)).to.be.false;
 
       expect(await strategy.hasRole(DEFAULT_ADMIN_ROLE, alice.address)).to.be
         .true;
@@ -217,7 +216,7 @@ describe('YearnStrategy', () => {
       expect(await strategy.investedAssets()).to.eq(0);
       expect(await strategy.hasAssets()).be.false;
 
-      await vault.connect(owner).updateInvested();
+      await vault.connect(admin).updateInvested();
 
       expect(await underlying.balanceOf(yVault.address)).to.eq(
         underlyingAmount,
@@ -232,7 +231,7 @@ describe('YearnStrategy', () => {
       let underlyingAmount = parseUnits('100', 18);
       await depositToVault(underlyingAmount);
 
-      const tx = await vault.connect(owner).updateInvested();
+      const tx = await vault.connect(admin).updateInvested();
 
       await expect(tx)
         .to.emit(strategy, 'StrategyInvested')
@@ -241,10 +240,10 @@ describe('YearnStrategy', () => {
 
     it('can be called multiple times', async () => {
       await depositToVault(parseUnits('100', 18));
-      await vault.connect(owner).updateInvested();
+      await vault.connect(admin).updateInvested();
 
       await depositToVault(parseUnits('10', 18));
-      await vault.connect(owner).updateInvested();
+      await vault.connect(admin).updateInvested();
 
       const totalUnderlying = parseUnits('110', 18).sub('37');
 
@@ -269,7 +268,7 @@ describe('YearnStrategy', () => {
 
     it('removes the requested funds from the yVault', async () => {
       await depositToVault(parseUnits('100'));
-      await vault.connect(owner).updateInvested();
+      await vault.connect(admin).updateInvested();
 
       const amountToWithdraw = parseUnits('30');
 
@@ -291,7 +290,7 @@ describe('YearnStrategy', () => {
 
     it('removes the requested funds from the strategy and the yVault', async () => {
       await depositToVault(parseUnits('100'));
-      await vault.connect(owner).updateInvested();
+      await vault.connect(admin).updateInvested();
       await underlying.mint(strategy.address, parseUnits('10'));
 
       await strategy.connect(manager).withdrawToVault(parseUnits('30'));
@@ -305,7 +304,7 @@ describe('YearnStrategy', () => {
 
     it('emits an event', async () => {
       await depositToVault(parseUnits('100'));
-      await vault.connect(owner).updateInvested();
+      await vault.connect(admin).updateInvested();
 
       const amountToWithdraw = parseUnits('30');
 
@@ -320,7 +319,7 @@ describe('YearnStrategy', () => {
 
     it('fails if the requested funds from the yVault are greater than available', async () => {
       await depositToVault(parseUnits('100'));
-      await vault.connect(owner).updateInvested();
+      await vault.connect(admin).updateInvested();
 
       const amountToWithdraw = parseUnits('101');
 
@@ -331,11 +330,11 @@ describe('YearnStrategy', () => {
   });
 
   const depositToVault = async (amount: BigNumber) => {
-    await vault.connect(owner).deposit(
+    await vault.connect(admin).deposit(
       depositParams.build({
         amount,
         inputToken: underlying.address,
-        claims: [claimParams.percent(100).to(owner.address).build()],
+        claims: [claimParams.percent(100).to(admin.address).build()],
       }),
     );
   };


### PR DESCRIPTION
On the transferOwnership method of the YearnStrategy contract, both ownable & AccessControl libraries were being used for the same functionality, when the work can be achieved by using just the AccessControl library. Updated the contract code & the tests for the same.