### PR TITLE
Subgraph Template Files Point to Symlinked ABIs Within Folder

### DIFF
--- a/subgraph/ethereum/subgraph.template.yaml
+++ b/subgraph/ethereum/subgraph.template.yaml
@@ -21,13 +21,13 @@ dataSources:
         - Foundation
       abis:
         - name: Vault
-          file: ../../artifacts/contracts/Vault.sol/Vault.json
+          file: ./abis/contracts/Vault.sol/Vault.json
         - name: IVault
-          file: ../../artifacts/contracts/vault/IVault.sol/IVault.json
+          file: ./abis/artifacts/contracts/vault/IVault.sol/IVault.json
         - name: IVaultSponsoring
-          file: ../../artifacts/contracts/vault/IVaultSponsoring.sol/IVaultSponsoring.json
+          file: ./abis/artifacts/contracts/vault/IVaultSponsoring.sol/IVaultSponsoring.json
         - name: IVaultSettings
-          file: ../../artifacts/contracts/vault/IVaultSettings.sol/IVaultSettings.json
+          file: ./abis/artifacts/contracts/vault/IVaultSettings.sol/IVaultSettings.json
       eventHandlers:
         - event: DepositMinted(indexed uint256,uint256,uint256,uint256,indexed address,indexed address,address,uint64,bytes,string)
           handler: handleDepositMinted

--- a/subgraph/ethereum/subgraph.template.yaml
+++ b/subgraph/ethereum/subgraph.template.yaml
@@ -23,11 +23,11 @@ dataSources:
         - name: Vault
           file: ./abis/contracts/Vault.sol/Vault.json
         - name: IVault
-          file: ./abis/artifacts/contracts/vault/IVault.sol/IVault.json
+          file: ./abis/contracts/vault/IVault.sol/IVault.json
         - name: IVaultSponsoring
-          file: ./abis/artifacts/contracts/vault/IVaultSponsoring.sol/IVaultSponsoring.json
+          file: ./abis/contracts/vault/IVaultSponsoring.sol/IVaultSponsoring.json
         - name: IVaultSettings
-          file: ./abis/artifacts/contracts/vault/IVaultSettings.sol/IVaultSettings.json
+          file: ./abis/contracts/vault/IVaultSettings.sol/IVaultSettings.json
       eventHandlers:
         - event: DepositMinted(indexed uint256,uint256,uint256,uint256,indexed address,indexed address,address,uint64,bytes,string)
           handler: handleDepositMinted

--- a/subgraph/polygon/subgraph.template.yaml
+++ b/subgraph/polygon/subgraph.template.yaml
@@ -20,7 +20,7 @@ dataSources:
         - DonationMint
       abis:
         - name: Donations
-          file: ../../artifacts/contracts/Donations.sol/Donations.json
+          file: ./abis/contracts/Donations.sol/Donations.json
       eventHandlers:
         - event: DonationMinted(indexed uint256,indexed uint128,indexed bytes32,address,uint256,uint256,address,string)
           handler: handleDonationMinted


### PR DESCRIPTION
- Point to ABIs that are symlinked to folders on same directory level as subgraph template files
- Required to avoid running into IPFS upload blocked errors during subgraph deployment