### PR TITLE
Remove subgraph check for burned shares

### DIFF
--- a/subgraph/ethereum/src/mappings/vault.ts
+++ b/subgraph/ethereum/src/mappings/vault.ts
@@ -86,10 +86,6 @@ export function handleYieldClaimed(event: YieldClaimed): void {
     }
   }
 
-  if (!event.params.burnedShares.equals(totalClaimedShares)) {
-    throw "The math for the claimed shares doesn't add up to the total burned shares";
-  }
-
   claimer.save();
   vault.save();
 }


### PR DESCRIPTION
These numbers will never add up correctly because of rounding issues. Whenever we convert from shares to/from wei we lose precision, and therefore these numbers will never add up. Fortunately, the difference is not that big, and if the UI indicates that it's an approximation, we should be fine. 