### PR TITLE
Audit I-1 fix

### DIFF
--- a/contracts/Vault.sol
+++ b/contracts/Vault.sol
@@ -179,16 +179,21 @@ contract Vault is
     //
 
     /**
-     * Transfers ownership of the Vault to another account, 
+     * Transfers ownership of the Vault to another account,
      * revoking all of previous owner's roles and setting them up for the new owner.
-     * 
+     *
      * @notice Can only be called by the current owner.
      *
      * @param _newOwner The new owner of the contract.
      */
-    function transferOwnership(address _newOwner) public override(Ownable) onlyOwner {
+    function transferOwnership(address _newOwner)
+        public
+        override(Ownable)
+        onlyOwner
+    {
         if (_newOwner == address(0x0)) revert VaultOwnerCannotBe0Address();
-        if (_newOwner == msg.sender) revert VaultCannotTransferOwnershipToSelf();
+        if (_newOwner == msg.sender)
+            revert VaultCannotTransferOwnershipToSelf();
 
         _transferOwnership(_newOwner);
 
@@ -452,6 +457,7 @@ contract Vault is
         if (_perfFee == 0) revert VaultNoPerformanceFee();
 
         accumulatedPerfFee = 0;
+        _rebalanceBeforeWithdrawing(_perfFee);
 
         emit FeeWithdrawn(_perfFee);
         underlying.safeTransfer(treasury, _perfFee);

--- a/test/audit_4.spec.ts
+++ b/test/audit_4.spec.ts
@@ -239,7 +239,7 @@ describe('Audit Tests 4', () => {
   describe('issue I-1 Vault#withdrawPerformanceFee', () => {
     beforeEach(() => beforeEachCommon(UNDERLYING_DECIMALS));
 
-    it.only("works when there's not enough funds in the vault by withdrawing from sync strategy", async () => {
+    it("works when there's not enough funds in the vault by withdrawing from sync strategy", async () => {
       const params = depositParams.build({
         amount: parseUnits('100'),
         inputToken: underlying.address,

--- a/test/audit_4.spec.ts
+++ b/test/audit_4.spec.ts
@@ -236,7 +236,7 @@ describe('Audit Tests 4', () => {
     });
   });
 
-  describe('issue I-1 Vault#withdrawPerfFee', () => {
+  describe('issue I-1 Vault#withdrawPerformanceFee', () => {
     beforeEach(() => beforeEachCommon(UNDERLYING_DECIMALS));
 
     it.only("works when there's not enough funds in the vault by withdrawing from sync strategy", async () => {


### PR DESCRIPTION
Resolved issue I-1 from the audit report - Vault.sol#withdrawPerformanceFee() Vault may not have sufficient balance for accumulatedPerfFee.
Solution: _rebalanceBeforeWithdrawing() called before transferring tokens to the treasury to ensure that the vault has enough balance for the transfer.