### PR TITLE
Audit L-4 fix

### DIFF
--- a/contracts/interfaces/yearn/IYearnVault.sol
+++ b/contracts/interfaces/yearn/IYearnVault.sol
@@ -1,9 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity =0.8.10;
 
-import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
-
-interface IYearnVault is IERC20Metadata {
+interface IYearnVault {
     function deposit(uint256 amount, address recipient)
         external
         returns (uint256);
@@ -17,4 +15,8 @@ interface IYearnVault is IERC20Metadata {
     ) external returns (uint256);
 
     function totalAssets() external view returns (uint256);
+
+    function balanceOf(address account) external view returns (uint256);
+
+    function decimals() external view returns (uint256);
 }


### PR DESCRIPTION
Resolved issue from the audit report - [L-4] ERC20 metadata interfaces on IYearnVault mismatch with Yearn's implementation.

Solution: There was a mismatch in IYearVault decimals() function return type, `uint8` was used instead of `uint256` which is actually how yearn vault implements this function. This wasn't causing any issues with fork tests but nevertheless, this has been changed so there is no mismatch anymore.