### PR TITLE
BaseStrategy contract refactoring

### DIFF
--- a/contracts/mock/MockBaseStrategy.sol
+++ b/contracts/mock/MockBaseStrategy.sol
@@ -9,7 +9,7 @@ import {BaseStrategy} from "../strategy/BaseStrategy.sol";
 contract MockBaseStrategy is BaseStrategy {
     constructor(
         address _vault,
-        address _underlying,
+        IERC20 _underlying,
         address _admin
     ) BaseStrategy(_vault, _underlying, _admin) {}
 

--- a/contracts/mock/MockBaseStrategy.sol
+++ b/contracts/mock/MockBaseStrategy.sol
@@ -11,9 +11,7 @@ contract MockBaseStrategy is BaseStrategy {
         address _vault,
         address _underlying,
         address _admin
-    ) {
-        _setup(_vault, _underlying, _admin);
-    }
+    ) BaseStrategy(_vault, _underlying, _admin) {}
 
     function isSync() external pure virtual override(IStrategy) returns (bool) {
         return true;

--- a/contracts/mock/MockStrategyAsync.sol
+++ b/contracts/mock/MockStrategyAsync.sol
@@ -8,7 +8,7 @@ import {MockStrategySync} from "./MockStrategySync.sol";
 contract MockStrategyAsync is MockStrategySync {
     constructor(
         address _vault,
-        address _underlying,
+        IERC20 _underlying,
         address _admin
     ) MockStrategySync(_vault, _underlying, _admin) {}
 

--- a/contracts/mock/MockStrategyAsync.sol
+++ b/contracts/mock/MockStrategyAsync.sol
@@ -8,7 +8,7 @@ import {MockStrategySync} from "./MockStrategySync.sol";
 contract MockStrategyAsync is MockStrategySync {
     constructor(
         address _vault,
-        IERC20 _underlying,
+        address _underlying,
         address _admin
     ) MockStrategySync(_vault, _underlying, _admin) {}
 

--- a/contracts/mock/MockStrategySync.sol
+++ b/contracts/mock/MockStrategySync.sol
@@ -12,11 +12,9 @@ import {CustomErrors} from "../interfaces/CustomErrors.sol";
 contract MockStrategySync is BaseStrategy {
     constructor(
         address _vault,
-        IERC20 _underlying,
+        address _underlying,
         address _admin
-    ) {
-        _setup(_vault, address(_underlying), _admin);
-    }
+    ) BaseStrategy(_vault, _underlying, _admin) {}
 
     function isSync() external pure virtual override(IStrategy) returns (bool) {
         return true;

--- a/contracts/mock/MockStrategySync.sol
+++ b/contracts/mock/MockStrategySync.sol
@@ -12,7 +12,7 @@ import {CustomErrors} from "../interfaces/CustomErrors.sol";
 contract MockStrategySync is BaseStrategy {
     constructor(
         address _vault,
-        address _underlying,
+        IERC20 _underlying,
         address _admin
     ) BaseStrategy(_vault, _underlying, _admin) {}
 

--- a/contracts/mock/anchor/AnchorStrategy.sol
+++ b/contracts/mock/anchor/AnchorStrategy.sol
@@ -81,7 +81,7 @@ contract AnchorStrategy is IAnchorStrategy, BaseStrategy {
         IERC20 _ustToken,
         IERC20 _aUstToken,
         address _admin
-    ) BaseStrategy(_vault, address(_ustToken), _admin) {
+    ) BaseStrategy(_vault, _ustToken, _admin) {
         if (_ethAnchorRouter == address(0))
             revert StrategyRouterCannotBe0Address();
         if (address(_aUstToken) == address(0))

--- a/contracts/mock/anchor/AnchorStrategy.sol
+++ b/contracts/mock/anchor/AnchorStrategy.sol
@@ -22,7 +22,6 @@ import {CustomErrors} from "../../interfaces/CustomErrors.sol";
 contract AnchorStrategy is IAnchorStrategy, BaseStrategy {
     using SafeERC20 for IERC20;
     using PercentMath for uint256;
-    using ERC165Query for address;
 
     // AnchorStrategy: no ust exist
     error StrategyNoUST();
@@ -36,9 +35,6 @@ contract AnchorStrategy is IAnchorStrategy, BaseStrategy {
     error StrategyRouterCannotBe0Address();
     // AnchorStrategy: yield token is 0x
     error StrategyYieldTokenCannotBe0Address();
-
-    // UST token address
-    IERC20 public immutable ustToken;
 
     // aUST token address (wrapped Anchor UST, received to accrue interest for an Anchor deposit)
     IERC20 public immutable aUstToken;
@@ -86,23 +82,13 @@ contract AnchorStrategy is IAnchorStrategy, BaseStrategy {
         IERC20 _aUstToken,
         address _admin
     ) BaseStrategy(_vault, address(_ustToken), _admin) {
-        if (_admin == address(0)) revert StrategyAdminCannotBe0Address();
         if (_ethAnchorRouter == address(0))
             revert StrategyRouterCannotBe0Address();
-        if (address(_ustToken) == address(0))
-            revert StrategyUnderlyingCannotBe0Address();
         if (address(_aUstToken) == address(0))
             revert StrategyYieldTokenCannotBe0Address();
-        if (!_vault.doesContractImplementInterface(type(IVault).interfaceId))
-            revert StrategyNotIVault();
 
-        _setupRole(DEFAULT_ADMIN_ROLE, _admin);
-        _setupRole(MANAGER_ROLE, _vault);
-
-        vault = _vault;
         ethAnchorRouter = IEthAnchorRouter(_ethAnchorRouter);
         aUstToUstFeed = _aUstToUstFeed;
-        ustToken = _ustToken;
         aUstToken = _aUstToken;
 
         _aUstToUstFeedMultiplier = 10**_aUstToUstFeed.decimals();
@@ -164,7 +150,7 @@ contract AnchorStrategy is IAnchorStrategy, BaseStrategy {
         if (ustBalance == 0) revert StrategyNoUST();
         pendingDeposits += ustBalance;
 
-        ustToken.safeIncreaseAllowance(address(ethAnchorRouter), ustBalance);
+        underlying.safeIncreaseAllowance(address(ethAnchorRouter), ustBalance);
         address operator = ethAnchorRouter.initDepositStable(ustBalance);
         depositOperations.push(
             Operation({operator: operator, amount: ustBalance})
@@ -286,7 +272,7 @@ contract AnchorStrategy is IAnchorStrategy, BaseStrategy {
 
         redeemOperations.pop();
 
-        ustToken.safeTransfer(vault, _getUnderlyingBalance());
+        underlying.safeTransfer(vault, _getUnderlyingBalance());
 
         emit FinishRedeemStable(operator, aUstAmount, ustAmount, ustAmount);
     }
@@ -304,14 +290,14 @@ contract AnchorStrategy is IAnchorStrategy, BaseStrategy {
      * @return underlying balance of strategy
      */
     function _getUnderlyingBalance() internal view returns (uint256) {
-        return ustToken.balanceOf(address(this));
+        return underlying.balanceOf(address(this));
     }
 
     /**
      * @return UST balance of strategy
      */
     function _getUstBalance() internal view returns (uint256) {
-        return ustToken.balanceOf(address(this));
+        return underlying.balanceOf(address(this));
     }
 
     /**

--- a/contracts/mock/anchor/AnchorStrategy.sol
+++ b/contracts/mock/anchor/AnchorStrategy.sol
@@ -85,7 +85,7 @@ contract AnchorStrategy is IAnchorStrategy, BaseStrategy {
         IERC20 _ustToken,
         IERC20 _aUstToken,
         address _admin
-    ) {
+    ) BaseStrategy(_vault, address(_ustToken), _admin) {
         if (_admin == address(0)) revert StrategyAdminCannotBe0Address();
         if (_ethAnchorRouter == address(0))
             revert StrategyRouterCannotBe0Address();

--- a/contracts/mock/anchor/MockAnchorStrategy.sol
+++ b/contracts/mock/anchor/MockAnchorStrategy.sol
@@ -29,7 +29,7 @@ contract MockAnchorStrategy is AnchorStrategy {
     function invest() external override(AnchorStrategy) onlyManager {}
 
     function withdrawToVault(uint256 amount) external override onlyManager {
-        ustToken.safeTransfer(vault, amount);
+        underlying.safeTransfer(vault, amount);
     }
 
     function investedAssets() external view override returns (uint256) {

--- a/contracts/strategy/BaseStrategy.sol
+++ b/contracts/strategy/BaseStrategy.sol
@@ -34,11 +34,11 @@ abstract contract BaseStrategy is IStrategy, AccessControl, CustomErrors {
      */
     constructor(
         address _vault,
-        address _underlying,
+        IERC20 _underlying,
         address _admin
     ) {
         if (_admin == address(0)) revert StrategyAdminCannotBe0Address();
-        if (_underlying == address(0))
+        if (address(_underlying) == address(0))
             revert StrategyUnderlyingCannotBe0Address();
         if (!_vault.doesContractImplementInterface(type(IVault).interfaceId))
             revert StrategyNotIVault();

--- a/contracts/strategy/BaseStrategy.sol
+++ b/contracts/strategy/BaseStrategy.sol
@@ -27,6 +27,29 @@ abstract contract BaseStrategy is IStrategy, AccessControl, CustomErrors {
     // the vault linked to this strategy
     address public vault;
 
+    /**
+     * @param _vault address of the vault that will use this strategy
+     * @param _underlying address of the underlying token
+     * @param _admin address of the administrator account
+     */
+    constructor(
+        address _vault,
+        address _underlying,
+        address _admin
+    ) {
+        if (_admin == address(0)) revert StrategyAdminCannotBe0Address();
+        if (_underlying == address(0))
+            revert StrategyUnderlyingCannotBe0Address();
+        if (!_vault.doesContractImplementInterface(type(IVault).interfaceId))
+            revert StrategyNotIVault();
+
+        vault = _vault;
+        underlying = IERC20(_underlying);
+
+        _setupRole(DEFAULT_ADMIN_ROLE, _admin);
+        _setupRole(MANAGER_ROLE, _vault);
+    }
+
     //
     // Modifiers
     //
@@ -59,33 +82,6 @@ abstract contract BaseStrategy is IStrategy, AccessControl, CustomErrors {
      */
     function transferAdminRights(address _newAdmin) external virtual onlyAdmin {
         _doTransferAdminRights(_newAdmin);
-    }
-
-    /**
-     * Sets up the essential fields required for any strategy implementation.
-     *
-     * @notice This is ment to be called only from the #constructor of the implemeting contracts.
-     *
-     * @param _vault address of the vault that will use this strategy
-     * @param _underlying address of the underlying token
-     * @param _admin address of the administrator account
-     */
-    function _setup(
-        address _vault,
-        address _underlying,
-        address _admin
-    ) internal {
-        if (_admin == address(0)) revert StrategyAdminCannotBe0Address();
-        if (_underlying == address(0))
-            revert StrategyUnderlyingCannotBe0Address();
-        if (!_vault.doesContractImplementInterface(type(IVault).interfaceId))
-            revert StrategyNotIVault();
-
-        vault = _vault;
-        underlying = IERC20(_underlying);
-
-        _setupRole(DEFAULT_ADMIN_ROLE, _admin);
-        _setupRole(MANAGER_ROLE, _vault);
     }
 
     /**

--- a/contracts/strategy/yearn/YearnStrategy.sol
+++ b/contracts/strategy/yearn/YearnStrategy.sol
@@ -52,7 +52,7 @@ contract YearnStrategy is BaseStrategy {
         address _vault,
         address _admin,
         address _yVault,
-        address _underlying
+        IERC20 _underlying
     ) BaseStrategy(_vault, _underlying, _admin) {
         if (_yVault == address(0)) revert StrategyYearnVaultCannotBe0Address();
 

--- a/contracts/strategy/yearn/YearnStrategy.sol
+++ b/contracts/strategy/yearn/YearnStrategy.sol
@@ -53,9 +53,7 @@ contract YearnStrategy is BaseStrategy {
         address _admin,
         address _yVault,
         address _underlying
-    ) {
-        _setup(_vault, _underlying, _admin);
-
+    ) BaseStrategy(_vault, _underlying, _admin) {
         if (_yVault == address(0)) revert StrategyYearnVaultCannotBe0Address();
 
         yVault = IYearnVault(_yVault);

--- a/contracts/test/strategy/TestAnchorUSTStrategy.sol
+++ b/contracts/test/strategy/TestAnchorUSTStrategy.sol
@@ -44,6 +44,6 @@ contract TestAnchorUSTStrategy is AnchorStrategy {
 
     // get aUST/UST exchange rate from eth anchor ExchangeRateFeeder contract
     function _aUstToUstExchangeRate() internal view override returns (uint256) {
-        return exchangeRateFeeder.exchangeRateOf(address(ustToken), true);
+        return exchangeRateFeeder.exchangeRateOf(address(underlying), true);
     }
 }

--- a/test/strategy/BaseStrategy.spec.ts
+++ b/test/strategy/BaseStrategy.spec.ts
@@ -60,7 +60,7 @@ describe('BaseStrategy', () => {
     await vault.setStrategy(strategy.address);
   });
 
-  describe('#setup/#constructor', () => {
+  describe('#constructor', () => {
     it('reverts if admin is address(0)', async () => {
       await expect(
         BaseStrategyFactory.deploy(
@@ -101,7 +101,7 @@ describe('BaseStrategy', () => {
     });
   });
 
-  describe('#changeAdmin/#transferAdminRights', () => {
+  describe('#transferAdminRights', () => {
     it('reverts if caller is not admin', async () => {
       await expect(
         strategy.connect(alice).transferAdminRights(alice.address),

--- a/test/strategy/anchor/AnchorStrategy.spec.ts
+++ b/test/strategy/anchor/AnchorStrategy.spec.ts
@@ -192,7 +192,7 @@ describe('AnchorStrategy', () => {
       expect(await strategy.aUstToUstFeed()).to.be.equal(
         mockAUstUstFeed.address,
       );
-      expect(await strategy.ustToken()).to.be.equal(ustToken.address);
+      expect(await strategy.underlying()).to.be.equal(ustToken.address);
       expect(await strategy.aUstToken()).to.be.equal(aUstToken.address);
       expect(await strategy.hasAssets()).to.be.equal(false);
     });


### PR DESCRIPTION
Moved the logic from `setup` function into `constructor` of the `BaseStrategy` contract