### PR TITLE
addressing audit issues G7, N8 & N9

### DIFF
--- a/contracts/Vault.sol
+++ b/contracts/Vault.sol
@@ -250,11 +250,12 @@ contract Vault is
     {
         uint256 claimerPrincipal = claimer[_to].totalPrincipal;
         uint256 claimerShares = claimer[_to].totalShares;
+        uint256 _totalUnderlyingMinusSponsored = totalUnderlyingMinusSponsored();
 
         uint256 currentClaimerPrincipal = _computeAmount(
             claimerShares,
             totalShares,
-            totalUnderlyingMinusSponsored()
+            _totalUnderlyingMinusSponsored
         );
 
         if (currentClaimerPrincipal <= claimerPrincipal) {
@@ -266,12 +267,12 @@ contract Vault is
         shares = _computeShares(
             yieldWithPerfFee,
             totalShares,
-            totalUnderlyingMinusSponsored()
+            _totalUnderlyingMinusSponsored
         );
         uint256 sharesAmount = _computeAmount(
             shares,
             totalShares,
-            totalUnderlyingMinusSponsored()
+            _totalUnderlyingMinusSponsored
         );
 
         perfFee = sharesAmount.pctOf(perfFeePct);

--- a/contracts/interfaces/CustomErrors.sol
+++ b/contracts/interfaces/CustomErrors.sol
@@ -18,7 +18,7 @@ interface CustomErrors {
     // Vault: no performance fee
     error VaultNoPerformanceFee();
 
-    // Vault: invalid investment fee
+    // Vault: invalid lossTolerance
     error VaultInvalidLossTolerance();
 
     // Vault: underlying cannot be 0x0
@@ -69,7 +69,7 @@ interface CustomErrors {
     // Vault: cannot deposit when the claimer is in debt
     error VaultCannotDepositWhenClaimerInDebt();
 
-    // Vault: cannot deposit when yield is negative
+    // Vault: cannot withdraw when yield is negative
     error VaultCannotWithdrawWhenYieldNegative();
 
     // Vault: nothing to do

--- a/contracts/strategy/liquity/LiquityStrategy.sol
+++ b/contracts/strategy/liquity/LiquityStrategy.sol
@@ -37,8 +37,6 @@ contract LiquityStrategy is
     error StrategyTokenTransferFailed(address token);
     error StrategyNothingToReinvest();
     error StrategySwapTargetCannotBe0Address();
-    error StrategyLQTYSwapDataEmpty();
-    error StrategyETHSwapDataEmpty();
     error StrategyLQTYSwapFailed();
     error StrategyETHSwapFailed();
 


### PR DESCRIPTION
Addressing minor issues from the audit report:
* [WP-G7] Cache function call results in the stack can save gas
* [WP-N8] Unused custom errors
* [WP-N9] Misleading comment