### PR TITLE
Audit fix m3

### DIFF
--- a/contracts/Vault.sol
+++ b/contracts/Vault.sol
@@ -50,7 +50,7 @@ contract Vault is
     //
 
     /// Role allowed to invest/desinvest from strategy
-    bytes32 public constant INVESTOR_ROLE = keccak256("INVESTOR_ROLE");
+    bytes32 public constant KEEPER_ROLE = keccak256("KEEPER_ROLE");
 
     /// Role allowed to change settings such as performance fee and investment fee
     bytes32 public constant SETTINGS_ROLE = keccak256("SETTINGS_ROLE");
@@ -154,7 +154,7 @@ contract Vault is
             revert VaultInvalidMinLockPeriod();
 
         _grantRole(DEFAULT_ADMIN_ROLE, _admin);
-        _grantRole(INVESTOR_ROLE, _admin);
+        _grantRole(KEEPER_ROLE, _admin);
         _grantRole(SETTINGS_ROLE, _admin);
         _grantRole(SPONSOR_ROLE, _admin);
 
@@ -188,9 +188,8 @@ contract Vault is
         _;
     }
 
-    modifier onlyInvestor() {
-        if (!hasRole(INVESTOR_ROLE, msg.sender))
-            revert VaultCallerNotInvestor();
+    modifier onlyKeeper() {
+        if (!hasRole(KEEPER_ROLE, msg.sender)) revert VaultCallerNotKeeper();
         _;
     }
 
@@ -213,12 +212,12 @@ contract Vault is
             revert VaultCannotTransferAdminRightsToSelf();
 
         _grantRole(DEFAULT_ADMIN_ROLE, _newAdmin);
-        _grantRole(INVESTOR_ROLE, _newAdmin);
+        _grantRole(KEEPER_ROLE, _newAdmin);
         _grantRole(SETTINGS_ROLE, _newAdmin);
         _grantRole(SPONSOR_ROLE, _newAdmin);
 
         _revokeRole(DEFAULT_ADMIN_ROLE, msg.sender);
-        _revokeRole(INVESTOR_ROLE, msg.sender);
+        _revokeRole(KEEPER_ROLE, msg.sender);
         _revokeRole(SETTINGS_ROLE, msg.sender);
         _revokeRole(SPONSOR_ROLE, msg.sender);
     }
@@ -433,7 +432,7 @@ contract Vault is
     }
 
     /// @inheritdoc IVault
-    function updateInvested() external override(IVault) onlyInvestor {
+    function updateInvested() external override(IVault) onlyKeeper {
         if (address(strategy) == address(0)) revert VaultStrategyNotSet();
 
         (uint256 maxInvestableAmount, uint256 alreadyInvested) = investState();
@@ -467,7 +466,7 @@ contract Vault is
     }
 
     /// @inheritdoc IVault
-    function withdrawPerformanceFee() external override(IVault) onlyInvestor {
+    function withdrawPerformanceFee() external override(IVault) onlyKeeper {
         uint256 _perfFee = accumulatedPerfFee;
         if (_perfFee == 0) revert VaultNoPerformanceFee();
 

--- a/contracts/interfaces/CustomErrors.sol
+++ b/contracts/interfaces/CustomErrors.sol
@@ -39,8 +39,8 @@ interface CustomErrors {
     // Vault: caller is not settings
     error VaultCallerNotSettings();
 
-    // Vault: caller is not investor
-    error VaultCallerNotInvestor();
+    // Vault: caller is not keeper
+    error VaultCallerNotKeeper();
 
     // Vault: caller is not sponsor
     error VaultCallerNotSponsor();

--- a/contracts/strategy/liquity/LiquityStrategy.sol
+++ b/contracts/strategy/liquity/LiquityStrategy.sol
@@ -45,9 +45,9 @@ contract LiquityStrategy is
     event StrategyRewardsClaimed(uint256 amountInLQTY, uint256 amountInETH);
     event StrategyRewardsReinvested(uint256 amountInLUSD);
 
-    // role for investing/withdrawing assets to/from the strategy (vault)
+    // role allowed to invest/withdraw assets to/from the strategy (vault)
     bytes32 public constant MANAGER_ROLE = keccak256("MANAGER_ROLE");
-    // role for calling harvest() and reinvestRewards()
+    // role allowed to call harvest() and reinvestRewards()
     bytes32 public constant KEEPER_ROLE = keccak256("KEEPER_ROLE");
 
     IERC20 public underlying; // LUSD token
@@ -103,6 +103,7 @@ contract LiquityStrategy is
         if (_keeper == address(0)) revert StrategyKeeperCannotBe0Address();
 
         _grantRole(DEFAULT_ADMIN_ROLE, _admin);
+        _grantRole(KEEPER_ROLE, _admin);
         _grantRole(MANAGER_ROLE, _vault);
         _grantRole(KEEPER_ROLE, _keeper);
 
@@ -134,7 +135,7 @@ contract LiquityStrategy is
         _grantRole(KEEPER_ROLE, _newAdmin);
 
         _revokeRole(DEFAULT_ADMIN_ROLE, msg.sender);
-        _grantRole(KEEPER_ROLE, _newAdmin);
+        _revokeRole(KEEPER_ROLE, msg.sender);
     }
 
     //

--- a/contracts/strategy/liquity/LiquityStrategy.sol
+++ b/contracts/strategy/liquity/LiquityStrategy.sol
@@ -131,8 +131,10 @@ contract LiquityStrategy is
             revert StrategyCannotTransferAdminRightsToSelf();
 
         _grantRole(DEFAULT_ADMIN_ROLE, _newAdmin);
+        _grantRole(KEEPER_ROLE, _newAdmin);
 
         _revokeRole(DEFAULT_ADMIN_ROLE, msg.sender);
+        _grantRole(KEEPER_ROLE, _newAdmin);
     }
 
     //

--- a/test/Vault.spec.ts
+++ b/test/Vault.spec.ts
@@ -58,7 +58,7 @@ describe('Vault', () => {
   const DENOMINATOR = BigNumber.from('10000');
 
   const DEFAULT_ADMIN_ROLE = constants.HashZero;
-  const INVESTOR_ROLE = utils.keccak256(utils.toUtf8Bytes('INVESTOR_ROLE'));
+  const KEEPER_ROLE = utils.keccak256(utils.toUtf8Bytes('KEEPER_ROLE'));
   const SETTINGS_ROLE = utils.keccak256(utils.toUtf8Bytes('SETTINGS_ROLE'));
   const SPONSOR_ROLE = utils.keccak256(utils.toUtf8Bytes('SPONSOR_ROLE'));
 
@@ -105,14 +105,11 @@ describe('Vault', () => {
       admin.address,
     );
 
-    ({
-      addUnderlyingBalance,
-      addYieldToVault,
-      removeUnderlyingFromVault,
-    } = createVaultHelpers({
-      vault,
-      underlying,
-    }));
+    ({ addUnderlyingBalance, addYieldToVault, removeUnderlyingFromVault } =
+      createVaultHelpers({
+        vault,
+        underlying,
+      }));
 
     await addUnderlyingBalance(alice, '1000');
     await addUnderlyingBalance(bob, '1000');
@@ -315,9 +312,7 @@ describe('Vault', () => {
       expect(
         await vault.hasRole(DEFAULT_ADMIN_ROLE, admin.address),
       ).to.be.equal(true);
-      expect(await vault.hasRole(INVESTOR_ROLE, admin.address)).to.be.equal(
-        true,
-      );
+      expect(await vault.hasRole(KEEPER_ROLE, admin.address)).to.be.equal(true);
       expect(await vault.hasRole(SPONSOR_ROLE, admin.address)).to.be.equal(
         true,
       );
@@ -360,7 +355,7 @@ describe('Vault', () => {
 
     it("revokes all previous admin's roles and sets them for the new admin", async () => {
       expect(await vault.hasRole(DEFAULT_ADMIN_ROLE, admin.address)).to.be.true;
-      expect(await vault.hasRole(INVESTOR_ROLE, admin.address)).to.be.true;
+      expect(await vault.hasRole(KEEPER_ROLE, admin.address)).to.be.true;
       expect(await vault.hasRole(SETTINGS_ROLE, admin.address)).to.be.true;
       expect(await vault.hasRole(SPONSOR_ROLE, admin.address)).to.be.true;
 
@@ -368,12 +363,12 @@ describe('Vault', () => {
 
       expect(await vault.hasRole(DEFAULT_ADMIN_ROLE, admin.address)).to.be
         .false;
-      expect(await vault.hasRole(INVESTOR_ROLE, admin.address)).to.be.false;
+      expect(await vault.hasRole(KEEPER_ROLE, admin.address)).to.be.false;
       expect(await vault.hasRole(SETTINGS_ROLE, admin.address)).to.be.false;
       expect(await vault.hasRole(SPONSOR_ROLE, admin.address)).to.be.false;
 
       expect(await vault.hasRole(DEFAULT_ADMIN_ROLE, alice.address)).to.be.true;
-      expect(await vault.hasRole(INVESTOR_ROLE, alice.address)).to.be.true;
+      expect(await vault.hasRole(KEEPER_ROLE, alice.address)).to.be.true;
       expect(await vault.hasRole(SETTINGS_ROLE, alice.address)).to.be.true;
       expect(await vault.hasRole(SPONSOR_ROLE, alice.address)).to.be.true;
     });
@@ -532,10 +527,10 @@ describe('Vault', () => {
       perfFee = newYield.mul(PERFORMANCE_FEE_PCT).div(DENOMINATOR);
     });
 
-    it('reverts if the caller is not investor', async () => {
+    it('reverts if the caller is not keeper', async () => {
       await expect(
         vault.connect(alice).withdrawPerformanceFee(),
-      ).to.be.revertedWith('VaultCallerNotInvestor');
+      ).to.be.revertedWith('VaultCallerNotKeeper');
     });
 
     it('withdraw performance fee and emit FeeWithdrawn event', async () => {
@@ -557,9 +552,9 @@ describe('Vault', () => {
   });
 
   describe('updateInvested', () => {
-    it('reverts if the caller is not investor', async () => {
+    it('reverts if the caller is not keeper', async () => {
       await expect(vault.connect(alice).updateInvested()).to.be.revertedWith(
-        'VaultCallerNotInvestor',
+        'VaultCallerNotKeeper',
       );
     });
 

--- a/test/strategy/liquity/LiquityStrategy.fork.spec.ts
+++ b/test/strategy/liquity/LiquityStrategy.fork.spec.ts
@@ -95,6 +95,7 @@ describe('Liquity Strategy (mainnet fork tests)', () => {
         lqtyStabilityPool.address,
         lqty.address,
         lusd.address,
+        admin.address, // keeper
       ],
       {
         kind: 'uups',
@@ -187,9 +188,10 @@ describe('Liquity Strategy (mainnet fork tests)', () => {
       const investedAssetsAfterPoolRebalancing = BigNumber.from(
         '9998816139652613137823',
       );
-      const expectedInvestedAssetsAfterReinvestingRewards = investedAssetsAfterPoolRebalancing
-        .add(LQTY_REWARD_IN_LUSD)
-        .add(ETH_REWARD_IN_LUSD);
+      const expectedInvestedAssetsAfterReinvestingRewards =
+        investedAssetsAfterPoolRebalancing
+          .add(LQTY_REWARD_IN_LUSD)
+          .add(ETH_REWARD_IN_LUSD);
       expect(await strategy.investedAssets()).to.eq(
         expectedInvestedAssetsAfterReinvestingRewards,
       );

--- a/test/strategy/liquity/LiquityStrategy.proxy.spec.ts
+++ b/test/strategy/liquity/LiquityStrategy.proxy.spec.ts
@@ -104,6 +104,7 @@ describe('LiquityStrategy Proxy', () => {
         stabilityPool.address,
         lqty.address,
         underlying.address,
+        admin.address, // keeper
       ],
       {
         kind: 'uups',

--- a/test/strategy/liquity/LiquityStrategy.spec.ts
+++ b/test/strategy/liquity/LiquityStrategy.spec.ts
@@ -224,6 +224,7 @@ describe('LiquityStrategy', () => {
       expect(await strategy.isSync()).to.be.true;
       expect(await strategy.hasRole(DEFAULT_ADMIN_ROLE, admin.address)).to.be
         .true;
+      expect(await strategy.hasRole(KEEPER_ROLE, admin.address)).to.be.true;
       expect(await strategy.hasRole(MANAGER_ROLE, vault.address)).to.be.true;
       expect(await strategy.hasRole(KEEPER_ROLE, keeper.address)).to.be.true;
 
@@ -262,13 +263,16 @@ describe('LiquityStrategy', () => {
     it('transfers admin role to the new admin account', async () => {
       expect(await strategy.hasRole(DEFAULT_ADMIN_ROLE, alice.address)).to.be
         .false;
+      expect(await strategy.hasRole(KEEPER_ROLE, alice.address)).to.be.false;
 
       await strategy.connect(admin).transferAdminRights(alice.address);
 
       expect(await strategy.hasRole(DEFAULT_ADMIN_ROLE, alice.address)).to.be
         .true;
+      expect(await strategy.hasRole(KEEPER_ROLE, alice.address)).to.be.true;
       expect(await strategy.hasRole(DEFAULT_ADMIN_ROLE, admin.address)).to.be
         .false;
+      expect(await strategy.hasRole(KEEPER_ROLE, admin.address)).to.be.false;
     });
   });
 

--- a/test/strategy/liquity/LiquityStrategy.spec.ts
+++ b/test/strategy/liquity/LiquityStrategy.spec.ts
@@ -20,6 +20,7 @@ describe('LiquityStrategy', () => {
   let admin: SignerWithAddress;
   let alice: SignerWithAddress;
   let manager: SignerWithAddress;
+  let keeper: SignerWithAddress;
   let vault: Vault;
   let stabilityPool: MockStabilityPool;
   let strategy: LiquityStrategy;
@@ -36,12 +37,13 @@ describe('LiquityStrategy', () => {
 
   const DEFAULT_ADMIN_ROLE = constants.HashZero;
   const MANAGER_ROLE = utils.keccak256(utils.toUtf8Bytes('MANAGER_ROLE'));
+  const KEEPER_ROLE = utils.keccak256(utils.toUtf8Bytes('KEEPER_ROLE'));
 
   // address of the '0x' contract performing the token swap
   const SWAP_TARGET = '0xdef1c0ded9bec7f1a1670819833240f027b25eff';
 
   beforeEach(async () => {
-    [admin, alice, manager] = await ethers.getSigners();
+    [admin, alice, manager, keeper] = await ethers.getSigners();
 
     const MockERC20 = await ethers.getContractFactory('MockERC20');
     underlying = await MockERC20.deploy(
@@ -82,6 +84,7 @@ describe('LiquityStrategy', () => {
         stabilityPool.address,
         lqty.address,
         underlying.address,
+        keeper.address,
       ],
       {
         kind: 'uups',
@@ -112,6 +115,7 @@ describe('LiquityStrategy', () => {
             stabilityPool.address,
             lqty.address,
             underlying.address,
+            keeper.address,
           ],
           {
             kind: 'uups',
@@ -130,6 +134,7 @@ describe('LiquityStrategy', () => {
             constants.AddressZero,
             lqty.address,
             underlying.address,
+            keeper.address,
           ],
           {
             kind: 'uups',
@@ -148,6 +153,7 @@ describe('LiquityStrategy', () => {
             stabilityPool.address,
             constants.AddressZero,
             underlying.address,
+            keeper.address,
           ],
           {
             kind: 'uups',
@@ -166,12 +172,32 @@ describe('LiquityStrategy', () => {
             stabilityPool.address,
             lqty.address,
             constants.AddressZero,
+            keeper.address,
           ],
           {
             kind: 'uups',
           },
         ),
       ).to.be.revertedWith('StrategyUnderlyingCannotBe0Address');
+    });
+
+    it('reverts if keeper is address(0)', async () => {
+      await expect(
+        upgrades.deployProxy(
+          LiquityStrategyFactory,
+          [
+            vault.address,
+            admin.address,
+            stabilityPool.address,
+            lqty.address,
+            underlying.address,
+            constants.AddressZero,
+          ],
+          {
+            kind: 'uups',
+          },
+        ),
+      ).to.be.revertedWith('StrategyKeeperCannotBe0Address');
     });
 
     it('reverts if vault does not have IVault interface', async () => {
@@ -184,6 +210,7 @@ describe('LiquityStrategy', () => {
             stabilityPool.address,
             lqty.address,
             underlying.address,
+            keeper.address,
           ],
           {
             kind: 'uups',
@@ -193,15 +220,19 @@ describe('LiquityStrategy', () => {
     });
 
     it('checks initial values', async () => {
+      // access control
       expect(await strategy.isSync()).to.be.true;
       expect(await strategy.hasRole(DEFAULT_ADMIN_ROLE, admin.address)).to.be
         .true;
       expect(await strategy.hasRole(MANAGER_ROLE, vault.address)).to.be.true;
+      expect(await strategy.hasRole(KEEPER_ROLE, keeper.address)).to.be.true;
+
+      // state
       expect(await strategy.vault()).to.eq(vault.address);
       expect(await strategy.stabilityPool()).to.eq(stabilityPool.address);
-
       expect(await strategy.underlying()).to.eq(underlying.address);
 
+      // functions
       expect(await strategy.hasAssets()).to.be.false;
       expect(
         await underlying.allowance(strategy.address, stabilityPool.address),
@@ -351,41 +382,41 @@ describe('LiquityStrategy', () => {
   });
 
   describe('#harvest', () => {
-    it('reverts if msg.sender is not admin', async () => {
+    it('reverts if msg.sender is not keeper', async () => {
       await expect(
         strategy.connect(alice).harvest(SWAP_TARGET, [], []),
-      ).to.be.revertedWith('StrategyCallerNotAdmin');
+      ).to.be.revertedWith('StrategyCallerNotKeeper');
     });
 
     it('revert if swapTarget is 0 address', async () => {
       await expect(
-        strategy.connect(admin).harvest(constants.AddressZero, [], []),
+        strategy.connect(keeper).harvest(constants.AddressZero, [], []),
       ).to.be.revertedWith('StrategySwapTargetCannotBe0Address');
     });
 
     it('reverts if eth & lqty rewards balance is zero', async () => {
       await expect(
-        strategy.connect(admin).harvest(SWAP_TARGET, [], []),
+        strategy.connect(keeper).harvest(SWAP_TARGET, [], []),
       ).to.be.revertedWith('StrategyNothingToReinvest');
     });
   });
 
   describe('#reinvestRewards', () => {
-    it('reverts if msg.sender is not admin', async () => {
+    it('reverts if msg.sender is not keeper', async () => {
       await expect(
         strategy.connect(alice).reinvestRewards(SWAP_TARGET, [], []),
-      ).to.be.revertedWith('StrategyCallerNotAdmin');
+      ).to.be.revertedWith('StrategyCallerNotKeeper');
     });
 
     it('revert if swapTarget is 0 address', async () => {
       await expect(
-        strategy.connect(admin).reinvestRewards(constants.AddressZero, [], []),
+        strategy.connect(keeper).reinvestRewards(constants.AddressZero, [], []),
       ).to.be.revertedWith('StrategySwapTargetCannotBe0Address');
     });
 
     it('reverts if eth & lqty rewards balance is zero', async () => {
       await expect(
-        strategy.connect(admin).reinvestRewards(SWAP_TARGET, [], []),
+        strategy.connect(keeper).reinvestRewards(SWAP_TARGET, [], []),
       ).to.be.revertedWith('StrategyNothingToReinvest');
     });
   });


### PR DESCRIPTION
Addressing the issue [WP-M3] Improper access control with the current roles and their privileges.
Solution: Added a specific "keeper" role responsible for calling the `harvest` and `reinvestRewards` functions 