### PR TITLE
Audit fix L5

### DIFF
--- a/contracts/Vault.sol
+++ b/contracts/Vault.sol
@@ -1066,7 +1066,7 @@ contract Vault is
             _claim.totalPrincipal;
 
         if (!_force && amountShares > claimerShares)
-            revert VaultCannotWithdrawMoreThanAvailable();
+            revert VaultMustUseForceWithdrawToAcceptLosses();
 
         uint256 sharesToBurn = amountShares;
 

--- a/contracts/interfaces/CustomErrors.sol
+++ b/contracts/interfaces/CustomErrors.sol
@@ -117,6 +117,9 @@ interface CustomErrors {
     // Vault: cannot withdraw more than the available amount
     error VaultCannotWithdrawMoreThanAvailable();
 
+    // Vault: must force withdraw to withdraw with a loss
+    error VaultMustUseForceWithdrawToAcceptLosses();
+
     // Vault: amount received does not match params
     error VaultAmountDoesNotMatchParams();
 

--- a/test/Vault.spec.ts
+++ b/test/Vault.spec.ts
@@ -105,14 +105,11 @@ describe('Vault', () => {
       admin.address,
     );
 
-    ({
-      addUnderlyingBalance,
-      addYieldToVault,
-      removeUnderlyingFromVault,
-    } = createVaultHelpers({
-      vault,
-      underlying,
-    }));
+    ({ addUnderlyingBalance, addYieldToVault, removeUnderlyingFromVault } =
+      createVaultHelpers({
+        vault,
+        underlying,
+      }));
 
     await addUnderlyingBalance(alice, '1000');
     await addUnderlyingBalance(bob, '1000');
@@ -2445,7 +2442,7 @@ describe('Vault', () => {
         .partialWithdraw(alice.address, [1], [parseUnits('25')]);
 
       await expect(tx).to.be.revertedWith(
-        'VaultCannotWithdrawMoreThanAvailable',
+        'VaultMustUseForceWithdrawToAcceptLosses',
       );
     });
 
@@ -2466,7 +2463,7 @@ describe('Vault', () => {
         .partialWithdraw(alice.address, [1], [parseUnits('100')]);
 
       await expect(tx).to.be.revertedWith(
-        'VaultCannotWithdrawMoreThanAvailable',
+        'VaultMustUseForceWithdrawToAcceptLosses',
       );
     });
 

--- a/test/audit_3.spec.ts
+++ b/test/audit_3.spec.ts
@@ -263,7 +263,7 @@ describe('Audit Tests 3', () => {
     // ## depositor1 withdraw
     await expect(
       vault.connect(depositor1).withdraw(depositor1.address, [1]),
-    ).to.revertedWith('VaultCannotWithdrawMoreThanAvailable');
+    ).to.revertedWith('VaultMustUseForceWithdrawToAcceptLosses');
 
     await vault.connect(depositor1).forceWithdraw(depositor1.address, [1]);
 


### PR DESCRIPTION
Addressing the issue [WP-L5] Wrong error thrown in _withdrawSingle() when amountShares > claimerShares.
Solution: Added a more specific error type for the case when a user tries to do regular withdrawal while experiencing a loss on his shares. 