### PR TITLE
audit issue L10

### DIFF
--- a/contracts/strategy/liquity/LiquityStrategy.sol
+++ b/contracts/strategy/liquity/LiquityStrategy.sol
@@ -40,7 +40,6 @@ contract LiquityStrategy is
     error StrategyLQTYSwapFailed();
     error StrategyETHSwapFailed();
 
-    event StrategyRewardsClaimed(uint256 amountInLQTY, uint256 amountInETH);
     event StrategyRewardsReinvested(uint256 amountInLUSD);
 
     bytes32 public constant MANAGER_ROLE = keccak256("MANAGER_ROLE");

--- a/contracts/strategy/liquity/LiquityStrategy.sol
+++ b/contracts/strategy/liquity/LiquityStrategy.sol
@@ -181,10 +181,6 @@ contract LiquityStrategy is
         // withdraws underlying amount and claims LQTY & ETH rewards
         stabilityPool.withdrawFromSP(amount);
 
-        uint256 lqtyRewards = lqty.balanceOf(address(this));
-        uint256 ethRewards = address(this).balance;
-        emit StrategyRewardsClaimed(lqtyRewards, ethRewards);
-
         // use balance instead of amount since amount could be greater than what was actually withdrawn
         uint256 balance = underlying.balanceOf(address(this));
         if (!underlying.transfer(vault, balance)) {

--- a/test/strategy/liquity/LiquityStrategy.fork.spec.ts
+++ b/test/strategy/liquity/LiquityStrategy.fork.spec.ts
@@ -187,9 +187,10 @@ describe('Liquity Strategy (mainnet fork tests)', () => {
       const investedAssetsAfterPoolRebalancing = BigNumber.from(
         '9998816139652613137823',
       );
-      const expectedInvestedAssetsAfterReinvestingRewards = investedAssetsAfterPoolRebalancing
-        .add(LQTY_REWARD_IN_LUSD)
-        .add(ETH_REWARD_IN_LUSD);
+      const expectedInvestedAssetsAfterReinvestingRewards =
+        investedAssetsAfterPoolRebalancing
+          .add(LQTY_REWARD_IN_LUSD)
+          .add(ETH_REWARD_IN_LUSD);
       expect(await strategy.investedAssets()).to.eq(
         expectedInvestedAssetsAfterReinvestingRewards,
       );
@@ -367,9 +368,6 @@ describe('Liquity Strategy (mainnet fork tests)', () => {
 
       expect(await strategy.investedAssets()).to.eq('4998816139652613137823');
       expect(await lusd.balanceOf(vault.address)).to.eq(amountToWithdraw);
-      expect(tx)
-        .to.emit(strategy, 'StrategyRewardsClaimed')
-        .withArgs(EXPECTED_LQTY_REWARD, EXPECTED_ETH_REWARD);
     });
   });
 });


### PR DESCRIPTION
removed the event emission since the backend is checking for the ETH & LQTY rewards contract balance periodically and not the event anyway.

(Also saves 4k gas in the withdrawToVault method)