### PR TITLE
Modifications to Unsponsored event

### DIFF
--- a/contracts/Vault.sol
+++ b/contracts/Vault.sol
@@ -689,8 +689,6 @@ contract Vault is
     /**
      * Withdraws the principal from the deposits with the ids provided in @param _ids and sends it to @param _to.
      *
-     * @notice the NFTs of the deposits will be burned.
-     *
      * @param _to Address that will receive the funds.
      * @param _ids Array with the ids of the deposits.
      * @param _force Boolean to specify if the action should be perfomed when there's loss.
@@ -781,8 +779,6 @@ contract Vault is
      * Withdraws the sponsored amount for the deposits with the ids provided
      * in @param _ids and sends it to @param _to.
      *
-     * @notice the NFTs of the deposits will be burned.
-     *
      * @param _to Address that will receive the funds.
      * @param _ids Array with the ids of the deposits.
      */
@@ -832,8 +828,6 @@ contract Vault is
 
     /**
      * Validates conditions for unsponsoring amount @param _amount of the deposit with the id @param _id.
-     *
-     * @notice The NFTs of the deposit will be burned if the deposited amount is equal to the amount being withdrawn.
      *
      * @param _id Id of the deposit.
      * @param _amount Amount to be unsponsored/withdrawn.
@@ -1018,7 +1012,7 @@ contract Vault is
     }
 
     /**
-     * Burns a deposit NFT and reduces the principal and shares of the claimer.
+     * Reduces the principal and shares of the claimer.
      * If there were any yield to be claimed, the claimer will also keep shares to withdraw later on.
      *
      * @notice This function doesn't transfer any funds, it only updates the state.

--- a/contracts/Vault.sol
+++ b/contracts/Vault.sol
@@ -848,13 +848,14 @@ contract Vault is
 
         bool isFull = _amount == _deposit.amount;
 
+        emit Unsponsored(_tokenId, _amount, _to, isFull);
+
         if (!isFull) {
             deposits[_tokenId].amount -= _amount;
-        } else {
-            delete deposits[_tokenId];
+            return;
         }
 
-        emit Unsponsored(_tokenId, _amount, _to, isFull);
+        delete deposits[_tokenId];
     }
 
     /**

--- a/contracts/vault/IVaultSponsoring.sol
+++ b/contracts/vault/IVaultSponsoring.sol
@@ -19,7 +19,7 @@ interface IVaultSponsoring {
         uint256 indexed id,
         uint256 amount,
         address indexed to,
-        bool isFull
+        bool burned
     );
 
     /**

--- a/contracts/vault/IVaultSponsoring.sol
+++ b/contracts/vault/IVaultSponsoring.sol
@@ -15,7 +15,12 @@ interface IVaultSponsoring {
     );
 
     /// Emitted when an existing sponsor withdraws
-    event Unsponsored(uint256 indexed id);
+    event Unsponsored(
+        uint256 indexed id,
+        uint256 amount,
+        address indexed to,
+        bool isFull
+    );
 
     /**
      * Total amount currently sponsored

--- a/contracts/vault/IVaultSponsoring.sol
+++ b/contracts/vault/IVaultSponsoring.sol
@@ -46,8 +46,6 @@ interface IVaultSponsoring {
      * It fails if the vault is underperforming and there are not enough funds
      * to withdraw the sponsored amount.
      *
-     * @notice the NFTs of the deposits will be burned.
-     *
      * @param _to Address that will receive the funds.
      * @param _ids Array with the ids of the deposits.
      */
@@ -57,9 +55,7 @@ interface IVaultSponsoring {
      * Withdraws the specified sponsored amounts @param _amounts for the deposits with the ids provided
      * in @param _ids and sends it to @param _to.
      *
-     * It fails if there are not enough funds to withdraw the specified amounts.
-     *
-     * @notice the NFTs of the deposits will be burned only if the whole deposit amount is withdrawn.
+     * @notice fails if there are not enough funds to withdraw the specified amounts.
      *
      * @param _to Address that will receive the funds.
      * @param _ids Array with the ids of the deposits.

--- a/subgraph/ethereum/src/mappings/vault.ts
+++ b/subgraph/ethereum/src/mappings/vault.ts
@@ -55,8 +55,9 @@ export function handleYieldClaimed(event: YieldClaimed): void {
     deposit.save();
 
     foundation.shares = foundation.shares.minus(depositClaimedShares);
-    foundation.amountClaimed =
-      foundation.amountClaimed.plus(depositClaimedAmount);
+    foundation.amountClaimed = foundation.amountClaimed.plus(
+      depositClaimedAmount,
+    );
     foundation.save();
 
     // If the claim is to the treasury, create a Donation
@@ -218,7 +219,12 @@ export function handleUnsponsored(event: Unsponsored): void {
   const sponsorId = event.params.id.toString();
   const sponsor = Sponsor.load(sponsorId)!;
 
-  sponsor.burned = true;
+  if (event.params.burned) {
+    sponsor.burned = true;
+  } else {
+    sponsor.amount = sponsor.amount.minus(event.params.amount);
+  }
+
   sponsor.save();
 }
 

--- a/subgraph/ethereum/subgraph.template.yaml
+++ b/subgraph/ethereum/subgraph.template.yaml
@@ -35,7 +35,7 @@ dataSources:
           handler: handleDepositWithdrawn
         - event: Sponsored(indexed uint256,uint256,indexed address,uint256)
           handler: handleSponsored
-        - event: Unsponsored(indexed uint256)
+        - event: Unsponsored(indexed uint256,uint256,indexed address,bool)
           handler: handleUnsponsored
         - event: YieldClaimed(address,indexed address,uint256,uint256,uint256,uint256,uint256)
           handler: handleYieldClaimed

--- a/subgraph/ethereum/tests/unit.test.ts
+++ b/subgraph/ethereum/tests/unit.test.ts
@@ -40,10 +40,8 @@ import {
   Foundation,
 } from '../src/types/schema';
 
-const MOCK_ADDRESS_1 =
-  '0xC80B3caAd6d2DE80Ac76a41d5F0072E36D2519Cd'.toLowerCase();
-const MOCK_ADDRESS_2 =
-  '0xE80B3caAd6d2DE80Ac76a41d5F0072E36D2519Ce'.toLowerCase();
+const MOCK_ADDRESS_1 = '0xC80B3caAd6d2DE80Ac76a41d5F0072E36D2519Cd'.toLowerCase();
+const MOCK_ADDRESS_2 = '0xE80B3caAd6d2DE80Ac76a41d5F0072E36D2519Ce'.toLowerCase();
 const TREASURY_ADDRESS = '0x4940c6e628da11ac0bdcf7f82be8579b4696fa33';
 
 test('handleTreasuryUpdated updates the treasury', () => {
@@ -112,6 +110,41 @@ test('handleSponsored creates a Sponsor', () => {
   assert.fieldEquals('Sponsor', '1', 'burned', 'false');
 });
 
+test('handleUnsponsored updates the amount sponsored', () => {
+  clearStore();
+
+  const sponsor = new Sponsor('1');
+  sponsor.burned = false;
+  sponsor.amount = BigInt.fromI32(2);
+  sponsor.save();
+
+  let mockEvent = newMockEvent();
+  const event = new Unsponsored(
+    mockEvent.address,
+    mockEvent.logIndex,
+    mockEvent.transactionLogIndex,
+    mockEvent.logType,
+    mockEvent.block,
+    mockEvent.transaction,
+    mockEvent.parameters,
+  );
+  event.parameters = new Array();
+
+  const idParam = newI32('id', 1);
+  const amount = newI32('amount', 1);
+  const to = newAddress('to', MOCK_ADDRESS_1);
+
+  event.parameters.push(idParam);
+  event.parameters.push(amount);
+  event.parameters.push(to);
+  event.parameters.push(newBool('burned', false));
+
+  handleUnsponsored(event);
+
+  assert.fieldEquals('Sponsor', '1', 'amount', '1');
+  assert.fieldEquals('Sponsor', '1', 'burned', 'false');
+});
+
 test('handleUnsponsored removes a Sponsor by marking as burned', () => {
   clearStore();
 
@@ -132,8 +165,13 @@ test('handleUnsponsored removes a Sponsor by marking as burned', () => {
   event.parameters = new Array();
 
   const idParam = newI32('id', 1);
+  const amount = newI32('amount', 1);
+  const to = newAddress('to', MOCK_ADDRESS_1);
 
   event.parameters.push(idParam);
+  event.parameters.push(amount);
+  event.parameters.push(to);
+  event.parameters.push(newBool('burned', true));
 
   handleUnsponsored(event);
 

--- a/test/Vault.spec.ts
+++ b/test/Vault.spec.ts
@@ -105,14 +105,11 @@ describe('Vault', () => {
       admin.address,
     );
 
-    ({
-      addUnderlyingBalance,
-      addYieldToVault,
-      removeUnderlyingFromVault,
-    } = createVaultHelpers({
-      vault,
-      underlying,
-    }));
+    ({ addUnderlyingBalance, addYieldToVault, removeUnderlyingFromVault } =
+      createVaultHelpers({
+        vault,
+        underlying,
+      }));
 
     await addUnderlyingBalance(alice, '1000');
     await addUnderlyingBalance(bob, '1000');
@@ -1127,7 +1124,7 @@ describe('Vault', () => {
       ).to.be.revertedWith('VaultCannotWithdrawMoreThanAvailable');
     });
 
-    it("doesn't emit 'Unsponsored event' if amount withdrawn is less than deposited amount", async () => {
+    it("emits 'Unsponsored' event if amount withdrawn is less than deposited amount", async () => {
       await addUnderlyingBalance(admin, '1000');
 
       await vault
@@ -1144,7 +1141,9 @@ describe('Vault', () => {
         .connect(admin)
         .partialUnsponsor(bob.address, [1], [parseUnits('500')]);
 
-      await expect(tx).not.to.emit(vault, 'Unsponsored');
+      await expect(tx)
+        .to.emit(vault, 'Unsponsored')
+        .withArgs(1, parseUnits('500'), bob.address, false);
     });
 
     it("emits 'Unsponsored' event if amount withdrawn equals deposited amount", async () => {
@@ -1164,7 +1163,9 @@ describe('Vault', () => {
         .connect(admin)
         .partialUnsponsor(bob.address, [1], [parseUnits('1000')]);
 
-      await expect(tx).to.emit(vault, 'Unsponsored').withArgs(1);
+      await expect(tx)
+        .to.emit(vault, 'Unsponsored')
+        .withArgs(1, parseUnits('1000'), bob.address, true);
     });
 
     it('fails if the caller is not the deposit owner', async () => {
@@ -1366,7 +1367,7 @@ describe('Vault', () => {
       );
     });
 
-    it('emits an event', async () => {
+    it("emits 'Unsponsored' event", async () => {
       await addUnderlyingBalance(admin, '1000');
 
       await vault
@@ -1381,7 +1382,9 @@ describe('Vault', () => {
       await moveForwardTwoWeeks();
       const tx = await vault.connect(admin).unsponsor(bob.address, [1]);
 
-      await expect(tx).to.emit(vault, 'Unsponsored').withArgs(1);
+      await expect(tx)
+        .to.emit(vault, 'Unsponsored')
+        .withArgs(1, parseUnits('500'), bob.address, true);
     });
 
     it('fails if the caller is not the owner', async () => {


### PR DESCRIPTION
Modified the unsponsored event to accommodate changes introduced with partial unsponsoring functionality, addressing additional comments left on the [PR188](https://github.com/lindy-labs/sc_solidity-contracts/pull/188) after the PR was closed.
Unsponsored event parameters extended to contain information about:
tokenId - id of the deposit being withdrawn (unsponsored)
amount - the amount being withdrawn
to - beneficiary address 
isFull - indicates if the deposit was fully withdrawn 