### PR TITLE
Audit Issue L10

### DIFF
--- a/contracts/strategy/liquity/LiquityStrategy.sol
+++ b/contracts/strategy/liquity/LiquityStrategy.sol
@@ -44,7 +44,6 @@ contract LiquityStrategy is
     error StrategyCallerNotKeeper();
     error StrategyKeeperCannotBe0Address();
 
-    event StrategyRewardsClaimed(uint256 amountInLQTY, uint256 amountInETH);
     event StrategyReinvested(uint256 amountInLUSD);
 
     // role allowed to invest/withdraw assets to/from the strategy (vault)
@@ -200,10 +199,6 @@ contract LiquityStrategy is
 
         // withdraws underlying amount and claims LQTY & ETH rewards
         stabilityPool.withdrawFromSP(amount);
-
-        uint256 lqtyRewards = lqty.balanceOf(address(this));
-        uint256 ethRewards = address(this).balance;
-        emit StrategyRewardsClaimed(lqtyRewards, ethRewards);
 
         // use balance instead of amount since amount could be greater than what was actually withdrawn
         uint256 balance = underlying.balanceOf(address(this));

--- a/test/strategy/liquity/LiquityStrategy.fork.spec.ts
+++ b/test/strategy/liquity/LiquityStrategy.fork.spec.ts
@@ -539,9 +539,6 @@ describe('Liquity Strategy (mainnet fork tests)', () => {
 
       expect(await strategy.investedAssets()).to.eq('4998816139652613137823');
       expect(await lusd.balanceOf(vault.address)).to.eq(amountToWithdraw);
-      expect(tx)
-        .to.emit(strategy, 'StrategyRewardsClaimed')
-        .withArgs(EXPECTED_LQTY_REWARD, EXPECTED_ETH_REWARD);
     });
   });
 });


### PR DESCRIPTION
removed the event emission since the backend is checking for the ETH & LQTY rewards contract balance periodically and not the event anyway.

(Also saves 4k gas in the withdrawToVault method)