### PR TITLE
[WP-I6] simplify calculation of ETH equivalent amount in LUSD in #transferYield

### DIFF
--- a/contracts/Vault.sol
+++ b/contracts/Vault.sol
@@ -377,11 +377,11 @@ contract Vault is
 
         if (address(strategy) != address(0)) {
             uint256 yieldTransferred = strategy.transferYield(_to, yield);
-            if (yieldTransferred == yield) {
+            if (yieldTransferred >= yield) {
                 return;
             }
 
-            yield = yield - yieldTransferred;
+            yield -= yieldTransferred;
         }
 
         _rebalanceBeforeWithdrawing(yield);

--- a/contracts/strategy/liquity/LiquityDCAStrategy.sol
+++ b/contracts/strategy/liquity/LiquityDCAStrategy.sol
@@ -35,9 +35,8 @@ contract LiquityDCAStrategy is LiquityStrategy {
 
         _sendETH(_to, ethToTransfer);
 
-        uint256 equivalentAmountInUnderlying = _amount.pctOf(
-            ethToTransfer.inPctOf(amountInETH)
-        );
+        uint256 equivalentAmountInUnderlying = (_amount * ethToTransfer) /
+            amountInETH;
 
         emit StrategyYieldTransferred(_to, equivalentAmountInUnderlying);
 

--- a/test/strategy/liquity/LiquityDCAStrategy.fork.spec.ts
+++ b/test/strategy/liquity/LiquityDCAStrategy.fork.spec.ts
@@ -212,11 +212,11 @@ describe('Liquity DCA Strategy (mainnet fork tests)', () => {
           .sub(await getTransactionGasCost(tx))
           .add(parseUnits('1')),
       );
-      // the difference in alice's end LUSD balance of ~97.16 and expected 100 LUSD comes from the differece in LUSD to ETH and ETH to LUSD exchange rates
-      // this means that some small amount yield for alice (~2.84 LUSD) is left in the vault after the yield was claimed
-      expect(await lusd.balanceOf(alice.address)).to.eq('97160101407531212992');
+      // the difference in alice's end LUSD balance of ~97.11 and expected 100 LUSD comes from the differece in LUSD to ETH and ETH to LUSD exchange rates
+      // this means that some small amount yield for alice (~2.89 LUSD) is left in the vault after the yield was claimed
+      expect(await lusd.balanceOf(alice.address)).to.eq('97108857183451805045');
       expect((await vault.yieldFor(alice.address)).claimableYield).to.eq(
-        '2839898592468787007', // in LUSD
+        '2891142816548194954', // in LUSD
       );
     });
   });


### PR DESCRIPTION
Addressing issue WP-I6 from the audit report -  Precision loss while calculating equivalentAmountInUnderlying