### PR TITLE
emit 'Disinvested' with actual amount withdrawn

### DIFF
--- a/contracts/Vault.sol
+++ b/contracts/Vault.sol
@@ -464,9 +464,9 @@ contract Vault is
             if (disinvestAmount < rebalanceMinimum)
                 revert VaultNotEnoughToRebalance();
 
-            strategy.withdrawToVault(disinvestAmount);
+            uint256 amountWithdrawn = strategy.withdrawToVault(disinvestAmount);
 
-            emit Disinvested(disinvestAmount);
+            emit Disinvested(amountWithdrawn);
 
             return;
         }
@@ -816,9 +816,9 @@ contract Vault is
         // to cover the transfer and leave the vault with the expected reserves
         uint256 needed = _amount + expectedReserves - vaultBalance;
 
-        strategy.withdrawToVault(needed);
+        uint256 amountWithdrawn = strategy.withdrawToVault(needed);
 
-        emit Disinvested(needed);
+        emit Disinvested(amountWithdrawn);
     }
 
     /**

--- a/contracts/mock/MockBaseStrategy.sol
+++ b/contracts/mock/MockBaseStrategy.sol
@@ -22,7 +22,14 @@ contract MockBaseStrategy is BaseStrategy {
     function invest() external virtual override(IStrategy) {}
 
     /// @inheritdoc IStrategy
-    function withdrawToVault(uint256 amount) external override(IStrategy) {}
+    function withdrawToVault(uint256)
+        external
+        pure
+        override(IStrategy)
+        returns (uint256)
+    {
+        return 0;
+    }
 
     /// @inheritdoc IStrategy
     function investedAssets()

--- a/contracts/mock/MockStrategyDirect.sol
+++ b/contracts/mock/MockStrategyDirect.sol
@@ -41,8 +41,14 @@ contract MockStrategyDirect is BaseStrategy {
     function invest() external virtual override(IStrategy) {}
 
     /// @inheritdoc IStrategy
-    function withdrawToVault(uint256 amount) external override(IStrategy) {
+    function withdrawToVault(uint256 amount)
+        external
+        override(IStrategy)
+        returns (uint256)
+    {
         underlying.transfer(vault, amount);
+
+        return amount;
     }
 
     /// @inheritdoc IStrategy

--- a/contracts/mock/anchor/AnchorStrategy.sol
+++ b/contracts/mock/anchor/AnchorStrategy.sol
@@ -115,6 +115,7 @@ contract AnchorStrategy is IAnchorStrategy, BaseStrategy {
         virtual
         override(IStrategy)
         onlyManager
+        returns (uint256)
     {
         if (amount == 0) revert StrategyAmountZero();
         uint256 _aUstToWithdraw = _estimateUstAmountInAUst(amount);
@@ -122,6 +123,8 @@ contract AnchorStrategy is IAnchorStrategy, BaseStrategy {
         if (pendingRedeems < _aUstToWithdraw) {
             initRedeemStable(_aUstToWithdraw - pendingRedeems);
         }
+
+        return 0;
     }
 
     /**

--- a/contracts/mock/anchor/MockAnchorStrategy.sol
+++ b/contracts/mock/anchor/MockAnchorStrategy.sol
@@ -28,8 +28,15 @@ contract MockAnchorStrategy is AnchorStrategy {
 
     function invest() external override(AnchorStrategy) onlyManager {}
 
-    function withdrawToVault(uint256 amount) external override onlyManager {
+    function withdrawToVault(uint256 amount)
+        external
+        override
+        onlyManager
+        returns (uint256)
+    {
         underlying.safeTransfer(vault, amount);
+
+        return amount;
     }
 
     function investedAssets() external view override returns (uint256) {

--- a/contracts/mock/liquity/MockLiquityStrategyV3.sol
+++ b/contracts/mock/liquity/MockLiquityStrategyV3.sol
@@ -5,12 +5,12 @@ import {LiquityStrategy} from "../../strategy/liquity/LiquityStrategy.sol";
 
 contract MockLiquityStrategyV3 is LiquityStrategy {
     function reinvest(
-        address _swapTarget,
-        uint256 _lqtyAmount,
-        bytes calldata _lqtySwapData,
+        address, // _swapTarget
+        uint256, // _lqtyAmount,
+        bytes calldata, // _lqtySwapData,
         uint256 _ethAmount,
-        bytes calldata _ethSwapData,
-        uint256 _amountOutMin
+        bytes calldata, // _ethSwapData,
+        uint256 // _amountOutMin
     ) external virtual override onlyKeeper {
         emit StrategyReinvested(_ethAmount);
     }

--- a/contracts/strategy/IStrategy.sol
+++ b/contracts/strategy/IStrategy.sol
@@ -45,8 +45,10 @@ interface IStrategy {
      * Withdraws the specified amount back to the vault (disinvests)
      *
      * @param amount Amount to withdraw
+     *
+     * @return actual amount withdrawn
      */
-    function withdrawToVault(uint256 amount) external;
+    function withdrawToVault(uint256 amount) external returns (uint256);
 
     /**
      * Transfers the @param _amount to @param _to in the more appropriate currency.

--- a/contracts/strategy/liquity/LiquityStrategy.sol
+++ b/contracts/strategy/liquity/LiquityStrategy.sol
@@ -265,6 +265,7 @@ contract LiquityStrategy is
         virtual
         override(IStrategy)
         onlyManager
+        returns (uint256)
     {
         if (amount == 0) revert StrategyAmountZero();
         if (amount > investedAssets()) revert StrategyNotEnoughShares();
@@ -277,6 +278,8 @@ contract LiquityStrategy is
         underlying.transfer(vault, balance);
 
         emit StrategyWithdrawn(balance);
+
+        return balance;
     }
 
     /**

--- a/contracts/strategy/rysk/RyskStrategy.sol
+++ b/contracts/strategy/rysk/RyskStrategy.sol
@@ -148,6 +148,7 @@ contract RyskStrategy is BaseStrategy {
         virtual
         override(IStrategy)
         onlyManager
+        returns (uint256)
     {
         if (_amount == 0) revert StrategyAmountZero();
 
@@ -166,6 +167,8 @@ contract RyskStrategy is BaseStrategy {
 
         emit StrategyWithdrawalInitiated(_amount);
         ryskLqPool.initiateWithdraw(sharesToWithdraw);
+
+        return 0;
     }
 
     /**

--- a/contracts/strategy/yearn/YearnStrategy.sol
+++ b/contracts/strategy/yearn/YearnStrategy.sol
@@ -129,6 +129,7 @@ contract YearnStrategy is BaseStrategy {
         virtual
         override(IStrategy)
         onlyManager
+        returns (uint256)
     {
         if (_amount == 0) revert StrategyAmountZero();
         uint256 uninvestedUnderlying = _getUnderlyingBalance();
@@ -155,6 +156,8 @@ contract YearnStrategy is BaseStrategy {
         underlying.safeTransfer(vault, _amount);
 
         emit StrategyWithdrawn(_amount);
+
+        return _amount;
     }
 
     /**

--- a/test/vault/Vault.spec.ts
+++ b/test/vault/Vault.spec.ts
@@ -684,7 +684,7 @@ describe('Vault', () => {
         );
       });
 
-      it('emits an event', async () => {
+      it('emits Disinvested event', async () => {
         await vault.connect(admin).setStrategy(strategy.address);
         await addYieldToVault('10');
         await underlying.mint(strategy.address, parseUnits('190'));
@@ -694,6 +694,19 @@ describe('Vault', () => {
         await expect(tx)
           .to.emit(vault, 'Disinvested')
           .withArgs(parseUnits('10'));
+      });
+
+      it('emits "Disinvested" event with amount withdrawn from the strategy', async () => {
+        await vault.connect(admin).setStrategy(strategy.address);
+        await addYieldToVault('10');
+        await underlying.mint(strategy.address, parseUnits('190'));
+        await strategy.setAmountToWithdrawReductionPct('1000'); // 10%
+
+        const tx = await vault.connect(admin).updateInvested();
+
+        await expect(tx)
+          .to.emit(vault, 'Disinvested')
+          .withArgs(parseUnits('9'));
       });
     });
   });

--- a/test/vault/VaultSyncMode.spec.ts
+++ b/test/vault/VaultSyncMode.spec.ts
@@ -158,6 +158,7 @@ describe('Vault in sync mode', () => {
         claims: [claimParams.percent(100).to(alice.address).build()],
       });
       await vault.connect(alice).deposit(params);
+      await strategy.setAmountToWithdrawReductionPct(500); // 5%
 
       await addYieldToVault('50');
       await vault.connect(owner).updateInvested();


### PR DESCRIPTION
Changed #withdrawToVault to return the actual amount withdrawn and use it to emit 'Disinvested' in the vault contract.
Addressing issue [#17](https://github.com/lindy-labs/audit_sandclock/issues/17). 